### PR TITLE
Fixes updateOnRender bug in Hosted apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ UpbeatUI implementations are available as NuGet packages:
 
 Three samples are included: one showing [manual setup](samples/ManualUpbeatUISample) and teardown without dependency injection, one showing manual setup and teardown with [dependency injection](samples/ServiceProvidedUpbeatUISample) using an **IServiceProvider**, and one showing [automatic setup and teardown](samples/HostedUpbeatUISample) using an **IHostBuilder**. All samples demonstrate the following capabilities:
 
-![UpbeatUI Sample](https://user-images.githubusercontent.com/20475952/111044956-6c7e1200-8400-11eb-82f3-1befa64c951b.gif)
+![UpbeatUI Sample](https://github.com/Pulselyre/UpbeatUI/assets/20475952/968f2465-43cb-4486-a671-c8a0d898022e)
 
 >Note: The background in the sample is OrangeRed to demonstrate how the effect can be configured. The default value is Gray.
 

--- a/samples/HostedUpbeatUISample/View/MenuControl.xaml
+++ b/samples/HostedUpbeatUISample/View/MenuControl.xaml
@@ -38,6 +38,15 @@
                 <TextBlock TextAlignment="Center"
                            Margin="5"
                            Text="{Binding SecondsElapsed}" />
+                <Ellipse Margin="5"
+                         HorizontalAlignment="Center"
+                         Height="10"
+                         Width="10">
+                        <Ellipse.Fill>
+                                <SolidColorBrush Color="Red"
+                                                 Opacity="{Binding Visibility}"/>
+                        </Ellipse.Fill>
+                </Ellipse>
             </StackPanel>
             <Button DockPanel.Dock="Bottom"
                     Margin="5"

--- a/samples/HostedUpbeatUISample/ViewModel/MenuViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/MenuViewModel.cs
@@ -3,6 +3,7 @@
  * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
  */
 using System;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Input;
 using UpbeatUI.Extensions.Hosting;
@@ -15,6 +16,7 @@ public class MenuViewModel : BaseViewModel, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
+    private readonly Stopwatch _stopwatch = new();
 
     public MenuViewModel(
         IUpbeatService upbeatService, // This will be a unique IUpbeatService created and injected by the IUpbeatStack specifically for this ViewModel.
@@ -24,6 +26,9 @@ public class MenuViewModel : BaseViewModel, IDisposable
         _upbeatService = upbeatService ?? throw new NullReferenceException(nameof(upbeatService));
         _ = hostedUpbeatService ?? throw new NullReferenceException(nameof(hostedUpbeatService));
         _sharedTimer = sharedTimer ?? throw new NullReferenceException(nameof(sharedTimer));
+
+        _stopwatch.Start();
+        _upbeatService.RegisterUpdateCallback(() => RaisePropertyChanged(nameof(Visibility))); // Registered "UpdateCallbacks" will be called each time the UI thread renders a new frame.
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
@@ -49,6 +54,7 @@ public class MenuViewModel : BaseViewModel, IDisposable
     public ICommand OpenRandomDataCommand { get; }
     public ICommand OpenSharedListCommand { get; }
     public string SecondsElapsed => $"{_sharedTimer.ElapsedSeconds} Seconds";
+    public double Visibility => Math.Abs(1000.0 - _stopwatch.ElapsedMilliseconds % 2000) / 1000.0; // Will be calculated on each "RaisePropertyChanged(nameof(Visibility))" and used in the View to control visibility of an ellipse. Cycles between full and no visibility every two seconds.
 
     public void Dispose() =>
         _sharedTimer.Ticked -= SharedTimerTicked;

--- a/samples/ManualUpbeatUISample/View/MenuControl.xaml
+++ b/samples/ManualUpbeatUISample/View/MenuControl.xaml
@@ -38,6 +38,15 @@
                 <TextBlock TextAlignment="Center"
                            Margin="5"
                            Text="{Binding SecondsElapsed}" />
+                <Ellipse Margin="5"
+                         HorizontalAlignment="Center"
+                         Height="10"
+                         Width="10">
+                        <Ellipse.Fill>
+                                <SolidColorBrush Color="Red"
+                                                 Opacity="{Binding Visibility}"/>
+                        </Ellipse.Fill>
+                </Ellipse>
             </StackPanel>
             <Button DockPanel.Dock="Bottom"
                     Margin="5"

--- a/samples/ManualUpbeatUISample/ViewModel/MenuViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/MenuViewModel.cs
@@ -3,6 +3,7 @@
  * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
  */
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -15,6 +16,7 @@ public class MenuViewModel : BaseViewModel, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
+    private readonly Stopwatch _stopwatch = new();
 
     public MenuViewModel(
         IUpbeatService upbeatService, // This will be a unique IUpbeatService created and injected by the IUpbeatStack specifically for this ViewModel.
@@ -24,6 +26,9 @@ public class MenuViewModel : BaseViewModel, IDisposable
         _upbeatService = upbeatService ?? throw new NullReferenceException(nameof(upbeatService));
         _ = closeApplicationCallbackAsync ?? throw new NullReferenceException(nameof(closeApplicationCallbackAsync));
         _sharedTimer = sharedTimer ?? throw new NullReferenceException(nameof(sharedTimer));
+
+        _stopwatch.Start();
+        _upbeatService.RegisterUpdateCallback(() => RaisePropertyChanged(nameof(Visibility))); // Registered "UpdateCallbacks" will be called each time the UI thread renders a new frame.
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
@@ -49,6 +54,7 @@ public class MenuViewModel : BaseViewModel, IDisposable
     public ICommand OpenRandomDataCommand { get; }
     public ICommand OpenSharedListCommand { get; }
     public string SecondsElapsed => $"{_sharedTimer.ElapsedSeconds} Seconds";
+    public double Visibility => Math.Abs(1000.0 - _stopwatch.ElapsedMilliseconds % 2000) / 1000.0; // Will be calculated on each "RaisePropertyChanged(nameof(Visibility))" and used in the View to control visibility of an ellipse. Cycles between full and no visibility every two seconds.
 
     public void Dispose() =>
         _sharedTimer.Ticked -= SharedTimerTicked;

--- a/samples/ServiceProvidedUpbeatUISample/View/MenuControl.xaml
+++ b/samples/ServiceProvidedUpbeatUISample/View/MenuControl.xaml
@@ -38,6 +38,15 @@
                 <TextBlock TextAlignment="Center"
                            Margin="5"
                            Text="{Binding SecondsElapsed}" />
+                <Ellipse Margin="5"
+                         HorizontalAlignment="Center"
+                         Height="10"
+                         Width="10">
+                        <Ellipse.Fill>
+                                <SolidColorBrush Color="Red"
+                                                 Opacity="{Binding Visibility}"/>
+                        </Ellipse.Fill>
+                </Ellipse>
             </StackPanel>
             <Button DockPanel.Dock="Bottom"
                     Margin="5"

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/MenuViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/MenuViewModel.cs
@@ -3,6 +3,7 @@
  * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
  */
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -15,6 +16,7 @@ public class MenuViewModel : BaseViewModel, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
+    private readonly Stopwatch _stopwatch = new();
 
     public MenuViewModel(
         IUpbeatService upbeatService, // This will be a unique IUpbeatService created and injected by the IUpbeatStack specifically for this ViewModel.
@@ -24,6 +26,9 @@ public class MenuViewModel : BaseViewModel, IDisposable
         _upbeatService = upbeatService ?? throw new NullReferenceException(nameof(upbeatService));
         _ = closeApplicationCallbackAsync ?? throw new NullReferenceException(nameof(closeApplicationCallbackAsync));
         _sharedTimer = sharedTimer ?? throw new NullReferenceException(nameof(sharedTimer));
+
+        _stopwatch.Start();
+        _upbeatService.RegisterUpdateCallback(() => RaisePropertyChanged(nameof(Visibility))); // Registered "UpdateCallbacks" will be called each time the UI thread renders a new frame.
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
@@ -49,6 +54,7 @@ public class MenuViewModel : BaseViewModel, IDisposable
     public ICommand OpenRandomDataCommand { get; }
     public ICommand OpenSharedListCommand { get; }
     public string SecondsElapsed => $"{_sharedTimer.ElapsedSeconds} Seconds";
+    public double Visibility => Math.Abs(1000.0 - _stopwatch.ElapsedMilliseconds % 2000) / 1000.0; // Will be calculated on each "RaisePropertyChanged(nameof(Visibility))" and used in the View to control visibility of an ellipse. Cycles between full and no visibility every two seconds.
 
     public void Dispose() =>
         _sharedTimer.Ticked -= SharedTimerTicked;

--- a/source/UpbeatUI.Extensions.Hosting/HostedUpbeatService.cs
+++ b/source/UpbeatUI.Extensions.Hosting/HostedUpbeatService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Extensions.Hosting;
+using UpbeatUI.Extensions.DependencyInjection;
 
 namespace UpbeatUI.Extensions.Hosting
 {
@@ -26,6 +27,7 @@ namespace UpbeatUI.Extensions.Hosting
                 {
                     Window mainWindow = null;
                     Task baseViewModelOpen = null;
+                    _upbeatStack = new ServiceProvidedUpbeatStack(_serviceProvider ?? throw new ArgumentNullException(nameof(_serviceProvider)));
                     foreach (var registerer in _upbeatHostBuilder.MappingRegisterers ?? throw new InvalidOperationException($"No {nameof(_upbeatHostBuilder.MappingRegisterers)} provided."))
                         registerer.Invoke(_upbeatStack);
                     mainWindow = _upbeatHostBuilder.WindowCreator?.Invoke() ?? throw new InvalidOperationException($"No {nameof(_upbeatHostBuilder.WindowCreator)} provided.");

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatApplicationService.cs
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatApplicationService.cs
@@ -12,16 +12,17 @@ namespace UpbeatUI.Extensions.Hosting
     internal class UpbeatApplicationService : IUpbeatApplicationService, IDisposable
     {
         protected readonly HostedUpbeatBuilder _upbeatHostBuilder;
-        protected readonly ServiceProvidedUpbeatStack _upbeatStack;
         protected readonly IHostApplicationLifetime _hostApplicationLifetime;
         protected readonly TaskCompletionSource<bool> _applicationTaskSource = new TaskCompletionSource<bool>();
         protected readonly TaskCompletionSource<bool> _forcedClosedTaskSource = new TaskCompletionSource<bool>();
+        protected readonly IServiceProvider _serviceProvider;
+        protected ServiceProvidedUpbeatStack _upbeatStack;
 
         protected UpbeatApplicationService(HostedUpbeatBuilder upbeatHostBuilder, IServiceProvider serviceProvider, IHostApplicationLifetime hostApplicationLifetime)
         {
             _upbeatHostBuilder = upbeatHostBuilder ?? throw new ArgumentNullException(nameof(upbeatHostBuilder));
             _hostApplicationLifetime = hostApplicationLifetime ?? throw new ArgumentNullException(nameof(hostApplicationLifetime));
-            _upbeatStack = new ServiceProvidedUpbeatStack(serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider)));
+            _serviceProvider = serviceProvider;
         }
 
         public async void CloseUpbeatApplication()


### PR DESCRIPTION
Fixes bug where app startup was out-of-order for Hosted apps, causing the `updateOnRender` feature to not work. Also adds a flashing light to the samples to test that it is working, and updates the demo .gif.