### PR TITLE
Deprecates BaseViewModel and DelegateCommand classes

### DIFF
--- a/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
+++ b/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
@@ -3,7 +3,7 @@
      See LICENSE.md or visit:
      https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
      -->
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.*" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.9" />
   </ItemGroup>
 

--- a/samples/HostedUpbeatUISample/ViewModel/BottomViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/BottomViewModel.cs
@@ -6,12 +6,14 @@ using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace HostedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class BottomViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class BottomViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
@@ -28,14 +30,14 @@ public class BottomViewModel : BaseViewModel, IDisposable
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        OpenMenuCommand = new DelegateCommand(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        OpenMenuCommand = new RelayCommand(
             () => _upbeatService.OpenViewModel( // Create a Parameters object for a ViewModel and pass it to the IUpbeatStack using OpenViewModel. The IUpbeatStack will use the configured mappings to create the appropriate ViewModel from the Parameters type.
                 new MenuViewModel.Parameters()));
-        OpenSharedListCommand = new DelegateCommand(
+        OpenSharedListCommand = new RelayCommand(
             () => _upbeatService.OpenViewModel(
                 new SharedListViewModel.Parameters()));
-        OpenRandomDataCommand = new DelegateCommand(
+        OpenRandomDataCommand = new RelayCommand(
             () => _upbeatService.OpenViewModel(
                 new RandomDataViewModel.Parameters()));
     }
@@ -64,7 +66,7 @@ public class BottomViewModel : BaseViewModel, IDisposable
     }
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "BottomViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/HostedUpbeatUISample/ViewModel/ConfirmPopupViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/ConfirmPopupViewModel.cs
@@ -4,6 +4,7 @@
  */
 using System;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace HostedUpbeatUISample.ViewModel;
@@ -16,8 +17,8 @@ internal class ConfirmPopupViewModel : PopupViewModel
         SharedTimer sharedTimer // This is a shared singleton service.
     ) : base(parameters, sharedTimer)
     {
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        ConfirmCommand = new DelegateCommand(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        ConfirmCommand = new RelayCommand(
             () =>
             {
                 parameters?.ConfirmCallback?.Invoke();

--- a/samples/HostedUpbeatUISample/ViewModel/MenuViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/MenuViewModel.cs
@@ -6,13 +6,15 @@ using System;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.Extensions.Hosting;
 using UpbeatUI.ViewModel;
 
 namespace HostedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class MenuViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class MenuViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
@@ -28,13 +30,13 @@ public class MenuViewModel : BaseViewModel, IDisposable
         _sharedTimer = sharedTimer ?? throw new NullReferenceException(nameof(sharedTimer));
 
         _stopwatch.Start();
-        _upbeatService.RegisterUpdateCallback(() => RaisePropertyChanged(nameof(Visibility))); // Registered "UpdateCallbacks" will be called each time the UI thread renders a new frame.
+        _upbeatService.RegisterUpdateCallback(() => OnPropertyChanged(nameof(Visibility))); // Registered "UpdateCallbacks" will be called each time the UI thread renders a new frame.
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        ExitCommand = new DelegateCommand(hostedUpbeatService.CloseUpbeatApplication);
-        OpenRandomDataCommand = new DelegateCommand(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        ExitCommand = new RelayCommand(hostedUpbeatService.CloseUpbeatApplication);
+        OpenRandomDataCommand = new RelayCommand(
             () =>
             {
                 // Create a Parameters object for a ViewModel and pass it to the IUpbeatStack using OpenViewModel. The IUpbeatStack will use the configured mappings to create the appropriate ViewModel from the Parameters type.
@@ -42,7 +44,7 @@ public class MenuViewModel : BaseViewModel, IDisposable
                 // Since this is Side Menu, it can close after the requested ViewModel is opened.
                 _upbeatService.Close();
             });
-        OpenSharedListCommand = new DelegateCommand(
+        OpenSharedListCommand = new RelayCommand(
             () =>
             {
                 _upbeatService.OpenViewModel(new SharedListViewModel.Parameters());
@@ -54,13 +56,13 @@ public class MenuViewModel : BaseViewModel, IDisposable
     public ICommand OpenRandomDataCommand { get; }
     public ICommand OpenSharedListCommand { get; }
     public string SecondsElapsed => $"{_sharedTimer.ElapsedSeconds} Seconds";
-    public double Visibility => Math.Abs(1000.0 - _stopwatch.ElapsedMilliseconds % 2000) / 1000.0; // Will be calculated on each "RaisePropertyChanged(nameof(Visibility))" and used in the View to control visibility of an ellipse. Cycles between full and no visibility every two seconds.
+    public double Visibility => Math.Abs(1000.0 - _stopwatch.ElapsedMilliseconds % 2000) / 1000.0; // Will be calculated on each "OnPropertyChanged(nameof(Visibility))" and used in the View to control visibility of an ellipse. Cycles between full and no visibility every two seconds.
 
     public void Dispose() =>
         _sharedTimer.Ticked -= SharedTimerTicked;
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "MenuViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/HostedUpbeatUISample/ViewModel/PopupViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/PopupViewModel.cs
@@ -4,12 +4,12 @@
  */
 using System;
 using System.Windows;
-using UpbeatUI.ViewModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace HostedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-internal class PopupViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+internal class PopupViewModel : ObservableObject, IDisposable
 {
     private readonly SharedTimer _sharedTimer;
 
@@ -36,7 +36,7 @@ internal class PopupViewModel : BaseViewModel, IDisposable
         _sharedTimer.Ticked -= SharedTimerTicked;
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "PopupViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/HostedUpbeatUISample/ViewModel/RandomDataViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/RandomDataViewModel.cs
@@ -7,12 +7,14 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace HostedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-internal class RandomDataViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+internal class RandomDataViewModel : ObservableObject, IDisposable
 {
     private const int MaxRandomLength = 15;
     private static readonly string RandomFormatString = new('0', MaxRandomLength);
@@ -33,8 +35,8 @@ internal class RandomDataViewModel : BaseViewModel, IDisposable
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        OpenPositionedPopupCommand = new DelegateCommand<Func<Point>>(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        OpenPositionedPopupCommand = new RelayCommand<Func<Point>>(
             pointGetter => _upbeatService.OpenViewModel( // Create a Parameters object for a ViewModel and pass it to the IUpbeatStack using OpenViewModel. The IUpbeatStack will use the configured mappings to create the appropriate ViewModel from the Parameters type.
                 new PopupViewModel.Parameters
                 {
@@ -42,7 +44,7 @@ internal class RandomDataViewModel : BaseViewModel, IDisposable
                     // The pointGetter parameter is a Func<Point> created by the View that will return the position within the window of the control that executed this command. See the bindings in View\RandomDataControl.xaml for details on how to bind a pointGetter() as a CommandParameter.
                     Position = pointGetter(),
                 }));
-        RefreshDataCommand = new DelegateCommand(RefreshData);
+        RefreshDataCommand = new RelayCommand(RefreshData);
 
         Data = new ReadOnlyObservableCollection<KeyValuePair<string, string>>(_data);
 
@@ -70,7 +72,7 @@ internal class RandomDataViewModel : BaseViewModel, IDisposable
             $"{(_random.NextDouble() * Math.Pow(10, MaxRandomLength)).ToString(RandomFormatString)}.{(_random.NextDouble() * Math.Pow(10, MaxRandomLength)).ToString(RandomFormatString)}");
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "RandomDataViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/HostedUpbeatUISample/ViewModel/SharedListDataViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/SharedListDataViewModel.cs
@@ -8,12 +8,14 @@ using System.Collections.Specialized;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace HostedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class SharedListDataViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class SharedListDataViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedList _sharedList;
@@ -34,8 +36,8 @@ public class SharedListDataViewModel : BaseViewModel, IDisposable
 
         _sharedList.StringAdded += SharedListStringAdded;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        AddStringCommand = new DelegateCommand<Func<Point>>(ExecuteAddStringAsync, pg => _strings.Count < 10);
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        AddStringCommand = new AsyncRelayCommand<Func<Point>>(ExecuteAddStringAsync, pg => _strings.Count < 10);
     }
 
     public INotifyCollectionChanged Strings { get; }

--- a/samples/HostedUpbeatUISample/ViewModel/SharedListViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/SharedListViewModel.cs
@@ -5,12 +5,14 @@
 using System;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace HostedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class SharedListViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class SharedListViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
@@ -30,7 +32,8 @@ public class SharedListViewModel : BaseViewModel, IDisposable
         _sharedTimer.Ticked += SharedTimerTicked;
         _sharedList.StringAdded += SharedListStringAdded;
 
-        CloseCommand = new DelegateCommand(_upbeatService.Close);
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        CloseCommand = new RelayCommand(_upbeatService.Close);
     }
 
     public ICommand CloseCommand { get; }
@@ -42,10 +45,10 @@ public class SharedListViewModel : BaseViewModel, IDisposable
         _sharedTimer.Ticked -= SharedTimerTicked;
 
     private void SharedListStringAdded(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(StringsCount))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(StringsCount))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "BottomViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/HostedUpbeatUISample/ViewModel/TextEntryPopupViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/TextEntryPopupViewModel.cs
@@ -4,6 +4,7 @@
  */
 using System;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace HostedUpbeatUISample.ViewModel;
@@ -16,8 +17,8 @@ internal class TextEntryPopupViewModel : PopupViewModel
         SharedTimer sharedTimer) // This is a shared singleton service.
         : base(parameters, sharedTimer)
     {
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed.
-        ReturnCommand = new DelegateCommand<string>(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        ReturnCommand = new RelayCommand<string>(
             entryString =>
             {
                 parameters?.ReturnCallback?.Invoke(entryString);

--- a/samples/ManualUpbeatUISample/ManualUpbeatUISample.csproj
+++ b/samples/ManualUpbeatUISample/ManualUpbeatUISample.csproj
@@ -3,13 +3,17 @@
      See LICENSE.md or visit:
      https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
      -->
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.*" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\source\UpbeatUI\UpbeatUI.csproj" />

--- a/samples/ManualUpbeatUISample/ViewModel/BottomViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/BottomViewModel.cs
@@ -6,12 +6,14 @@ using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ManualUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class BottomViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class BottomViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
@@ -28,14 +30,14 @@ public class BottomViewModel : BaseViewModel, IDisposable
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        OpenMenuCommand = new DelegateCommand(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        OpenMenuCommand = new RelayCommand(
             () => _upbeatService.OpenViewModel( // Create a Parameters object for a ViewModel and pass it to the IUpbeatStack using OpenViewModel. The IUpbeatStack will use the configured mappings to create the appropriate ViewModel from the Parameters type.
                 new MenuViewModel.Parameters()));
-        OpenSharedListCommand = new DelegateCommand(
+        OpenSharedListCommand = new RelayCommand(
             () => _upbeatService.OpenViewModel(
                 new SharedListViewModel.Parameters()));
-        OpenRandomDataCommand = new DelegateCommand(
+        OpenRandomDataCommand = new RelayCommand(
             () => _upbeatService.OpenViewModel(
                 new RandomDataViewModel.Parameters()));
     }
@@ -64,7 +66,7 @@ public class BottomViewModel : BaseViewModel, IDisposable
     }
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "BottomViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/ManualUpbeatUISample/ViewModel/ConfirmPopupViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/ConfirmPopupViewModel.cs
@@ -4,6 +4,7 @@
  */
 using System;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ManualUpbeatUISample.ViewModel;
@@ -16,8 +17,8 @@ internal class ConfirmPopupViewModel : PopupViewModel
         SharedTimer sharedTimer // This is a shared singleton service.
     ) : base(parameters, sharedTimer)
     {
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        ConfirmCommand = new DelegateCommand(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        ConfirmCommand = new RelayCommand(
             () =>
             {
                 parameters?.ConfirmCallback?.Invoke();

--- a/samples/ManualUpbeatUISample/ViewModel/MenuViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/MenuViewModel.cs
@@ -7,12 +7,14 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ManualUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class MenuViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class MenuViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
@@ -28,13 +30,13 @@ public class MenuViewModel : BaseViewModel, IDisposable
         _sharedTimer = sharedTimer ?? throw new NullReferenceException(nameof(sharedTimer));
 
         _stopwatch.Start();
-        _upbeatService.RegisterUpdateCallback(() => RaisePropertyChanged(nameof(Visibility))); // Registered "UpdateCallbacks" will be called each time the UI thread renders a new frame.
+        _upbeatService.RegisterUpdateCallback(() => OnPropertyChanged(nameof(Visibility))); // Registered "UpdateCallbacks" will be called each time the UI thread renders a new frame.
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        ExitCommand = new DelegateCommand(closeApplicationCallbackAsync);
-        OpenRandomDataCommand = new DelegateCommand(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        ExitCommand = new AsyncRelayCommand(closeApplicationCallbackAsync);
+        OpenRandomDataCommand = new RelayCommand(
             () =>
             {
                 // Create a Parameters object for a ViewModel and pass it to the IUpbeatStack using OpenViewModel. The IUpbeatStack will use the configured mappings to create the appropriate ViewModel from the Parameters type.
@@ -42,7 +44,7 @@ public class MenuViewModel : BaseViewModel, IDisposable
                 // Since this is Side Menu, it can close after the requested ViewModel is opened.
                 _upbeatService.Close();
             });
-        OpenSharedListCommand = new DelegateCommand(
+        OpenSharedListCommand = new RelayCommand(
             () =>
             {
                 _upbeatService.OpenViewModel(new SharedListViewModel.Parameters());
@@ -54,13 +56,13 @@ public class MenuViewModel : BaseViewModel, IDisposable
     public ICommand OpenRandomDataCommand { get; }
     public ICommand OpenSharedListCommand { get; }
     public string SecondsElapsed => $"{_sharedTimer.ElapsedSeconds} Seconds";
-    public double Visibility => Math.Abs(1000.0 - _stopwatch.ElapsedMilliseconds % 2000) / 1000.0; // Will be calculated on each "RaisePropertyChanged(nameof(Visibility))" and used in the View to control visibility of an ellipse. Cycles between full and no visibility every two seconds.
+    public double Visibility => Math.Abs(1000.0 - _stopwatch.ElapsedMilliseconds % 2000) / 1000.0; // Will be calculated on each "OnPropertyChanged(nameof(Visibility))" and used in the View to control visibility of an ellipse. Cycles between full and no visibility every two seconds.
 
     public void Dispose() =>
         _sharedTimer.Ticked -= SharedTimerTicked;
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "MenuViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/ManualUpbeatUISample/ViewModel/PopupViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/PopupViewModel.cs
@@ -4,12 +4,12 @@
  */
 using System;
 using System.Windows;
-using UpbeatUI.ViewModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ManualUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-internal class PopupViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+internal class PopupViewModel : ObservableObject, IDisposable
 {
     private readonly SharedTimer _sharedTimer;
 
@@ -36,7 +36,7 @@ internal class PopupViewModel : BaseViewModel, IDisposable
         _sharedTimer.Ticked -= SharedTimerTicked;
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "PopupViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/ManualUpbeatUISample/ViewModel/RandomDataViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/RandomDataViewModel.cs
@@ -7,12 +7,14 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ManualUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-internal class RandomDataViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+internal class RandomDataViewModel : ObservableObject, IDisposable
 {
     private const int MaxRandomLength = 15;
     private static readonly string RandomFormatString = new('0', MaxRandomLength);
@@ -33,8 +35,8 @@ internal class RandomDataViewModel : BaseViewModel, IDisposable
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        OpenPositionedPopupCommand = new DelegateCommand<Func<Point>>(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        OpenPositionedPopupCommand = new RelayCommand<Func<Point>>(
             pointGetter => _upbeatService.OpenViewModel( // Create a Parameters object for a ViewModel and pass it to the IUpbeatStack using OpenViewModel. The IUpbeatStack will use the configured mappings to create the appropriate ViewModel from the Parameters type.
                 new PopupViewModel.Parameters
                 {
@@ -42,7 +44,7 @@ internal class RandomDataViewModel : BaseViewModel, IDisposable
                     // The pointGetter parameter is a Func<Point> created by the View that will return the position within the window of the control that executed this command. See the bindings in View\RandomDataControl.xaml for details on how to bind a pointGetter() as a CommandParameter.
                     Position = pointGetter(),
                 }));
-        RefreshDataCommand = new DelegateCommand(RefreshData);
+        RefreshDataCommand = new RelayCommand(RefreshData);
 
         Data = new ReadOnlyObservableCollection<KeyValuePair<string, string>>(_data);
 
@@ -70,7 +72,7 @@ internal class RandomDataViewModel : BaseViewModel, IDisposable
             $"{(_random.NextDouble() * Math.Pow(10, MaxRandomLength)).ToString(RandomFormatString)}.{(_random.NextDouble() * Math.Pow(10, MaxRandomLength)).ToString(RandomFormatString)}");
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "RandomDataViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/ManualUpbeatUISample/ViewModel/SharedListDataViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/SharedListDataViewModel.cs
@@ -8,12 +8,14 @@ using System.Collections.Specialized;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ManualUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class SharedListDataViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class SharedListDataViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedList _sharedList;
@@ -34,8 +36,8 @@ public class SharedListDataViewModel : BaseViewModel, IDisposable
 
         _sharedList.StringAdded += SharedListStringAdded;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        AddStringCommand = new DelegateCommand<Func<Point>>(ExecuteAddStringAsync, pg => _strings.Count < 10);
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        AddStringCommand = new AsyncRelayCommand<Func<Point>>(ExecuteAddStringAsync, pg => _strings.Count < 10);
     }
 
     public INotifyCollectionChanged Strings { get; }

--- a/samples/ManualUpbeatUISample/ViewModel/SharedListViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/SharedListViewModel.cs
@@ -5,12 +5,14 @@
 using System;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ManualUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class SharedListViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class SharedListViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
@@ -30,7 +32,8 @@ public class SharedListViewModel : BaseViewModel, IDisposable
         _sharedTimer.Ticked += SharedTimerTicked;
         _sharedList.StringAdded += SharedListStringAdded;
 
-        CloseCommand = new DelegateCommand(_upbeatService.Close);
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        CloseCommand = new RelayCommand(_upbeatService.Close);
     }
 
     public ICommand CloseCommand { get; }
@@ -42,10 +45,10 @@ public class SharedListViewModel : BaseViewModel, IDisposable
         _sharedTimer.Ticked -= SharedTimerTicked;
 
     private void SharedListStringAdded(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(StringsCount))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(StringsCount))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "BottomViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/ManualUpbeatUISample/ViewModel/TextEntryPopupViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/TextEntryPopupViewModel.cs
@@ -4,6 +4,7 @@
  */
 using System;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ManualUpbeatUISample.ViewModel;
@@ -16,8 +17,8 @@ internal class TextEntryPopupViewModel : PopupViewModel
         SharedTimer sharedTimer) // This is a shared singleton service.
         : base(parameters, sharedTimer)
     {
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed.
-        ReturnCommand = new DelegateCommand<string>(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        ReturnCommand = new RelayCommand<string>(
             entryString =>
             {
                 parameters?.ReturnCallback?.Invoke(entryString);

--- a/samples/ServiceProvidedUpbeatUISample/ServiceProvidedUpbeatUISample.csproj
+++ b/samples/ServiceProvidedUpbeatUISample/ServiceProvidedUpbeatUISample.csproj
@@ -3,7 +3,7 @@
      See LICENSE.md or visit:
      https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
      -->
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
   </ItemGroup>
 

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/BottomViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/BottomViewModel.cs
@@ -6,12 +6,14 @@ using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ServiceProvidedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class BottomViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class BottomViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
@@ -28,14 +30,14 @@ public class BottomViewModel : BaseViewModel, IDisposable
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        OpenMenuCommand = new DelegateCommand(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        OpenMenuCommand = new RelayCommand(
             () => _upbeatService.OpenViewModel( // Create a Parameters object for a ViewModel and pass it to the IUpbeatStack using OpenViewModel. The IUpbeatStack will use the configured mappings to create the appropriate ViewModel from the Parameters type.
                 new MenuViewModel.Parameters()));
-        OpenSharedListCommand = new DelegateCommand(
+        OpenSharedListCommand = new RelayCommand(
             () => _upbeatService.OpenViewModel(
                 new SharedListViewModel.Parameters()));
-        OpenRandomDataCommand = new DelegateCommand(
+        OpenRandomDataCommand = new RelayCommand(
             () => _upbeatService.OpenViewModel(
                 new RandomDataViewModel.Parameters()));
     }
@@ -64,7 +66,7 @@ public class BottomViewModel : BaseViewModel, IDisposable
     }
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "BottomViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/ConfirmPopupViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/ConfirmPopupViewModel.cs
@@ -4,6 +4,7 @@
  */
 using System;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ServiceProvidedUpbeatUISample.ViewModel;
@@ -16,8 +17,8 @@ internal class ConfirmPopupViewModel : PopupViewModel
         SharedTimer sharedTimer // This is a shared singleton service.
     ) : base(parameters, sharedTimer)
     {
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        ConfirmCommand = new DelegateCommand(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        ConfirmCommand = new RelayCommand(
             () =>
             {
                 parameters?.ConfirmCallback?.Invoke();

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/PopupViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/PopupViewModel.cs
@@ -4,12 +4,12 @@
  */
 using System;
 using System.Windows;
-using UpbeatUI.ViewModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ServiceProvidedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-internal class PopupViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+internal class PopupViewModel : ObservableObject, IDisposable
 {
     private readonly SharedTimer _sharedTimer;
 
@@ -36,7 +36,7 @@ internal class PopupViewModel : BaseViewModel, IDisposable
         _sharedTimer.Ticked -= SharedTimerTicked;
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "PopupViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/RandomDataViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/RandomDataViewModel.cs
@@ -7,12 +7,14 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ServiceProvidedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-internal class RandomDataViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+internal class RandomDataViewModel : ObservableObject, IDisposable
 {
     private const int MaxRandomLength = 15;
     private static readonly string RandomFormatString = new('0', MaxRandomLength);
@@ -33,8 +35,8 @@ internal class RandomDataViewModel : BaseViewModel, IDisposable
 
         _sharedTimer.Ticked += SharedTimerTicked;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        OpenPositionedPopupCommand = new DelegateCommand<Func<Point>>(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        OpenPositionedPopupCommand = new RelayCommand<Func<Point>>(
             pointGetter => _upbeatService.OpenViewModel( // Create a Parameters object for a ViewModel and pass it to the IUpbeatStack using OpenViewModel. The IUpbeatStack will use the configured mappings to create the appropriate ViewModel from the Parameters type.
                 new PopupViewModel.Parameters
                 {
@@ -42,7 +44,7 @@ internal class RandomDataViewModel : BaseViewModel, IDisposable
                     // The pointGetter parameter is a Func<Point> created by the View that will return the position within the window of the control that executed this command. See the bindings in View\RandomDataControl.xaml for details on how to bind a pointGetter() as a CommandParameter.
                     Position = pointGetter(),
                 }));
-        RefreshDataCommand = new DelegateCommand(RefreshData);
+        RefreshDataCommand = new RelayCommand(RefreshData);
 
         Data = new ReadOnlyObservableCollection<KeyValuePair<string, string>>(_data);
 
@@ -70,7 +72,7 @@ internal class RandomDataViewModel : BaseViewModel, IDisposable
             $"{(_random.NextDouble() * Math.Pow(10, MaxRandomLength)).ToString(RandomFormatString)}.{(_random.NextDouble() * Math.Pow(10, MaxRandomLength)).ToString(RandomFormatString)}");
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "RandomDataViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/SharedListDataViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/SharedListDataViewModel.cs
@@ -8,12 +8,14 @@ using System.Collections.Specialized;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ServiceProvidedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class SharedListDataViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class SharedListDataViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedList _sharedList;
@@ -34,8 +36,8 @@ public class SharedListDataViewModel : BaseViewModel, IDisposable
 
         _sharedList.StringAdded += SharedListStringAdded;
 
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
-        AddStringCommand = new DelegateCommand<Func<Point>>(ExecuteAddStringAsync, pg => _strings.Count < 10);
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        AddStringCommand = new AsyncRelayCommand<Func<Point>>(ExecuteAddStringAsync, pg => _strings.Count < 10);
     }
 
     public INotifyCollectionChanged Strings { get; }

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/SharedListViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/SharedListViewModel.cs
@@ -5,12 +5,14 @@
 using System;
 using System.Windows;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ServiceProvidedUpbeatUISample.ViewModel;
 
-// This extends BaseViewModel, which provides pre-written SetProperty and RaisePropertyChanged methods.
-public class SharedListViewModel : BaseViewModel, IDisposable
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public class SharedListViewModel : ObservableObject, IDisposable
 {
     private readonly IUpbeatService _upbeatService;
     private readonly SharedTimer _sharedTimer;
@@ -30,7 +32,8 @@ public class SharedListViewModel : BaseViewModel, IDisposable
         _sharedTimer.Ticked += SharedTimerTicked;
         _sharedList.StringAdded += SharedListStringAdded;
 
-        CloseCommand = new DelegateCommand(_upbeatService.Close);
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        CloseCommand = new RelayCommand(_upbeatService.Close);
     }
 
     public ICommand CloseCommand { get; }
@@ -42,10 +45,10 @@ public class SharedListViewModel : BaseViewModel, IDisposable
         _sharedTimer.Ticked -= SharedTimerTicked;
 
     private void SharedListStringAdded(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(StringsCount))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(StringsCount))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     private void SharedTimerTicked(object sender, EventArgs e) =>
-        Application.Current.Dispatcher.Invoke(() => RaisePropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
+        Application.Current.Dispatcher.Invoke(() => OnPropertyChanged(nameof(SecondsElapsed))); // Ensure that the PropertyChanged event is raised on the UI thread
 
     // This nested Parameters class (full class name: "BottomViewModel.Parameters") is what other ViewModels will create instances of to tell the IUpbeatStack what type of child ViewModel to add to the stack.
     public class Parameters

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/TextEntryPopupViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/TextEntryPopupViewModel.cs
@@ -4,6 +4,7 @@
  */
 using System;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
 
 namespace ServiceProvidedUpbeatUISample.ViewModel;
@@ -16,8 +17,8 @@ internal class TextEntryPopupViewModel : PopupViewModel
         SharedTimer sharedTimer) // This is a shared singleton service.
         : base(parameters, sharedTimer)
     {
-        // DelegateCommand is a common convenience ICommand implementation to call methods or lambda expressions when the command is executed.
-        ReturnCommand = new DelegateCommand<string>(
+        // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. It can be used to call methods or lambda expressions when the command is executed. It supports both async and non-async methods/lambdas.
+        ReturnCommand = new RelayCommand<string>(
             entryString =>
             {
                 parameters?.ReturnCallback?.Invoke(entryString);

--- a/source/UpbeatUI/ViewModel/BaseViewModel.cs
+++ b/source/UpbeatUI/ViewModel/BaseViewModel.cs
@@ -14,6 +14,7 @@ namespace UpbeatUI.ViewModel
     /// <summary>
     /// Provides a base class with convenience methods for ViewModels.
     /// </summary>
+    [Obsolete("'BaseViewModel' abstract class is deprecated and will be removed in the next major release; consider using the 'CommunityToolkit.Mvvm' NuGet package and 'ObservableObject' class instead.}")]
     public abstract class BaseViewModel : INotifyPropertyChanged
     {
         private static readonly Dictionary<string, PropertyChangedEventArgs> _eventArgCache = new Dictionary<string, PropertyChangedEventArgs>();

--- a/source/UpbeatUI/ViewModel/DelegateCommand.cs
+++ b/source/UpbeatUI/ViewModel/DelegateCommand.cs
@@ -11,6 +11,7 @@ namespace UpbeatUI.ViewModel
     /// <summary>
     /// Provides a convenient means of creating an <see cref="ICommand"/> using delegates provided by the parent class.
     /// </summary>
+    [Obsolete("'DelegateCommand' class is deprecated and will be removed in the next major release; consider using the 'CommunityToolkit.Mvvm' NuGet package and 'RelayCommand' class instead.}")]
     public sealed class DelegateCommand : ICommand
     {
         private readonly Action _execute;
@@ -107,6 +108,7 @@ namespace UpbeatUI.ViewModel
     /// Provides a convenient means of creating an <see cref="ICommand"/> with a parameter using delegates provided by the parent class.
     /// </summary>
     /// <typeparam name="T">The type of the command's parameter.</typeparam>
+    [Obsolete("'DelegateCommand<T>' class is deprecated and will be removed in the next major release; consider using the 'CommunityToolkit.Mvvm' NuGet package and 'RelayCommand<T>' class instead.}")]
     public sealed class DelegateCommand<T> : ICommand
     {
         private readonly Action<T> _execute;

--- a/source/UpbeatUI/ViewModel/UpbeatStack.RelayCommand.cs
+++ b/source/UpbeatUI/ViewModel/UpbeatStack.RelayCommand.cs
@@ -1,0 +1,70 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace UpbeatUI.ViewModel
+{
+    public partial class UpbeatStack
+    {
+        private class RelayCommand : ICommand
+        {
+            private readonly Action _execute;
+            private readonly Func<bool> _canExecute;
+            private bool _isAsyncExecuting = false;
+
+            public RelayCommand(Func<Task> executeAsync, Func<bool> canExecute = null, Action<Exception> exceptionCallback = null, bool singleExecution = true)
+            {
+                if (executeAsync == null)
+                    throw new ArgumentNullException(nameof(executeAsync));
+                _execute = async () =>
+                {
+                    try
+                    {
+                        _isAsyncExecuting = singleExecution;
+                        await executeAsync();
+                    }
+                    catch (Exception e)
+                    {
+                        if (exceptionCallback == null)
+                            throw;
+                        exceptionCallback(e);
+                    }
+                    finally
+                    {
+                        if (_isAsyncExecuting)
+                        {
+                            _isAsyncExecuting = false;
+                            CommandManager.InvalidateRequerySuggested();
+                        }
+                    }
+                };
+                _canExecute = canExecute;
+            }
+
+            public event EventHandler CanExecuteChanged
+            {
+                add { CommandManager.RequerySuggested += value; }
+                remove { CommandManager.RequerySuggested -= value; }
+            }
+
+            public bool CanExecute(object parameter) =>
+                CanExecute();
+
+            public bool CanExecute() =>
+                !_isAsyncExecuting && (_canExecute?.Invoke() ?? true);
+
+            public void Execute(object parameter) =>
+                Execute();
+
+            public void Execute()
+            {
+                if (CanExecute())
+                    _execute.Invoke();
+            }
+        }
+    }
+}

--- a/source/UpbeatUI/ViewModel/UpbeatStack.UpbeatService.cs
+++ b/source/UpbeatUI/ViewModel/UpbeatStack.UpbeatService.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace UpbeatUI.ViewModel
 {
-    public partial class UpbeatStack : BaseViewModel, IDisposable
+    public partial class UpbeatStack
     {
         private class UpbeatService : IUpbeatService
         {

--- a/source/UpbeatUI/ViewModel/UpbeatStack.UpbeatServiceDeferrer.cs
+++ b/source/UpbeatUI/ViewModel/UpbeatStack.UpbeatServiceDeferrer.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace UpbeatUI.ViewModel
 {
-    public partial class UpbeatStack : BaseViewModel, IDisposable
+    public partial class UpbeatStack
     {
         private class UpbeatServiceDeferrer : ActionDeferrer
         {

--- a/source/UpbeatUI/ViewModel/UpbeatStack.cs
+++ b/source/UpbeatUI/ViewModel/UpbeatStack.cs
@@ -17,7 +17,7 @@ namespace UpbeatUI.ViewModel
     /// <summary>
     /// Represents a stack of ViewModels and provides methods and commands for controlling them.
     /// </summary>
-    public partial class UpbeatStack : BaseViewModel, IUpbeatStack, IDisposable
+    public partial class UpbeatStack : IUpbeatStack, IDisposable
     {
         protected delegate object ViewModelInstantiator(IUpbeatService upbeatService, object parameters);
 
@@ -35,7 +35,7 @@ namespace UpbeatUI.ViewModel
         {
             _updateOnRender = updateOnRender;
             ViewModels = new ReadOnlyObservableCollection<object>(_openViewModels);
-            RemoveTopViewModelCommand = new DelegateCommand(
+            RemoveTopViewModelCommand = new RelayCommand(
                 () => TryRemoveViewModelAsync(_openViewModels.Last()),
                 CanRemoveTopViewModel, singleExecution: false);
             if (_updateOnRender)


### PR DESCRIPTION
1. Deprecates the `BaseViewModel` and `DelegateCommand` classes and recommends using [`CommunityToolkit.Mvvm`](https://www.nuget.org/packages/CommunityToolkit.Mvvm) implementations instead.
2. Adds a private `ICommand` implementation for `UpbeatStack`.
3. Updates the samples to use [`CommunityToolkit.Mvvm`](https://www.nuget.org/packages/CommunityToolkit.Mvvm) implementations.