### PR TITLE
Deprecates SynchronizableCollection

### DIFF
--- a/UpbeatUI.build.ps1
+++ b/UpbeatUI.build.ps1
@@ -118,6 +118,9 @@ task BuildTests {
 }
 task bt BuildTests
 
+task BuildSamples BuildManualSample, BuildServiceProvidedSample, BuildHostedSample
+task bs BuildSamples
+
 task BuildManualSample {
   dotnet build `
     '.\samples\ManualUpbeatUISample' `

--- a/samples/HostedUpbeatUISample/ViewModel/SharedListDataViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/SharedListDataViewModel.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
+using UpbeatUI.ViewModel.ListSynchronize;
 
 namespace HostedUpbeatUISample.ViewModel;
 
@@ -20,7 +21,7 @@ public class SharedListDataViewModel : ObservableObject, IDisposable
     private readonly IUpbeatService _upbeatService;
     private readonly SharedList _sharedList;
     // Synchronizable collection is an extension of ObservableCollection
-    private readonly SynchronizableCollection<string> _strings = new();
+    private readonly ObservableCollection<string> _strings = new();
 
     public SharedListDataViewModel(
     // This will be a unique IUpbeatService created and injected by the IUpbeatStack specifically for this ViewModel.

--- a/samples/ManualUpbeatUISample/ViewModel/SharedListDataViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/SharedListDataViewModel.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
+using UpbeatUI.ViewModel.ListSynchronize;
 
 namespace ManualUpbeatUISample.ViewModel;
 
@@ -20,7 +21,7 @@ public class SharedListDataViewModel : ObservableObject, IDisposable
     private readonly IUpbeatService _upbeatService;
     private readonly SharedList _sharedList;
     // Synchronizable collection is an extension of ObservableCollection
-    private readonly SynchronizableCollection<string> _strings = new();
+    private readonly ObservableCollection<string> _strings = new();
 
     public SharedListDataViewModel(
     // This will be a unique IUpbeatService created and injected by the IUpbeatStack specifically for this ViewModel.

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/SharedListDataViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/SharedListDataViewModel.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using UpbeatUI.ViewModel;
+using UpbeatUI.ViewModel.ListSynchronize;
 
 namespace ServiceProvidedUpbeatUISample.ViewModel;
 
@@ -20,7 +21,7 @@ public class SharedListDataViewModel : ObservableObject, IDisposable
     private readonly IUpbeatService _upbeatService;
     private readonly SharedList _sharedList;
     // Synchronizable collection is an extension of ObservableCollection
-    private readonly SynchronizableCollection<string> _strings = new();
+    private readonly ObservableCollection<string> _strings = new();
 
     public SharedListDataViewModel(
     // This will be a unique IUpbeatService created and injected by the IUpbeatStack specifically for this ViewModel.

--- a/source/UpbeatUI.Tests/ListSynchronize_Tests.cs
+++ b/source/UpbeatUI.Tests/ListSynchronize_Tests.cs
@@ -1,0 +1,187 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using NUnit.Framework;
+using UpbeatUI.ViewModel.ListSynchronize;
+
+namespace UpbeatUI.Tests.ListSynchronize_Tests
+{
+    public class Values_Only
+    {
+        [Test]
+        public void Synchronizes_Empty_Array_With_Values()
+        {
+            var observableCollection = new ObservableCollection<int>();
+            var newValues = Enumerable.Range(0, 5).ToList();
+            ExecuteAndTestSync(observableCollection, newValues);
+        }
+
+        [Test]
+        public void Synchronizes_Full_Array_With_New_Values()
+        {
+            var observableCollection = new ObservableCollection<int>() { 11, 12, 13 };
+            var newValues = Enumerable.Range(0, 5).ToList();
+            ExecuteAndTestSync(observableCollection, newValues);
+        }
+
+        [Test]
+        public void Synchronizes_Full_Array_With_No_Values()
+        {
+            var observableCollection = new ObservableCollection<int>() { 11, 12, 13 };
+            var newValues = new List<int>();
+            ExecuteAndTestSync(observableCollection, newValues);
+        }
+
+        private static void ExecuteAndTestSync(
+            ObservableCollection<int> observableCollection,
+            IList<int> newValues
+        )
+        {
+            var originalSize = observableCollection.Count;
+            var changedCount = 0;
+            observableCollection.CollectionChanged += (o, e) => changedCount++;
+            observableCollection.Synchronize(newValues);
+            Assert.AreEqual(newValues.Count, observableCollection.Count);
+            Assert.AreEqual(Math.Max(originalSize, newValues.Count), changedCount);
+            for (var i = 0; i < newValues.Count; i++)
+            {
+                Assert.AreEqual(newValues[i], observableCollection[i]);
+            }
+        }
+    }
+
+    public class With_Synchronizer
+    {
+        [Test]
+        public void Synchronizes_Values_With_Syncrhonizer()
+        {
+            var observableCollection = new ObservableCollection<TestObjectWithDefaultConstructor>();
+            var newValues = Enumerable.Range(0, 5).ToList();
+            ExecuteAndTestSync(observableCollection, newValues);
+        }
+
+        [Test]
+        public void Synchronizes_Full_Array_With_New_Values()
+        {
+            var observableCollection = new ObservableCollection<TestObjectWithDefaultConstructor>()
+                {
+                    new TestObjectWithDefaultConstructor { Value = "11" },
+                    new TestObjectWithDefaultConstructor { Value = "12" },
+                    new TestObjectWithDefaultConstructor { Value = "13" }
+                };
+            var newValues = Enumerable.Range(0, 5).ToList();
+            ExecuteAndTestSync(observableCollection, newValues);
+        }
+
+        [Test]
+        public void Synchronizes_Full_Array_With_No_Values()
+        {
+            var observableCollection = new ObservableCollection<TestObjectWithDefaultConstructor>()
+                {
+                    new TestObjectWithDefaultConstructor { Value = "11" },
+                    new TestObjectWithDefaultConstructor { Value = "12" },
+                    new TestObjectWithDefaultConstructor { Value = "13" }
+                };
+            var newValues = new List<int>();
+            ExecuteAndTestSync(observableCollection, newValues);
+        }
+
+        private static void ExecuteAndTestSync(
+            ObservableCollection<TestObjectWithDefaultConstructor> observableCollection,
+            IList<int> newValues
+        )
+        {
+            var originalSize = observableCollection.Count;
+            var changedCount = 0;
+            observableCollection.CollectionChanged += (o, e) => changedCount++;
+            observableCollection.Synchronize(
+                (i, to) => to.Value = i.ToString(),
+                newValues
+                );
+            Assert.AreEqual(newValues.Count, observableCollection.Count);
+            Assert.AreEqual(Math.Abs(originalSize - newValues.Count), changedCount);
+            for (var i = 0; i < newValues.Count; i++)
+            {
+                Assert.AreEqual(newValues[i].ToString(), observableCollection[i].Value);
+            }
+        }
+    }
+
+    public class With_Synchronizer_And_Blank_Creator
+    {
+        [Test]
+        public void Synchronizes_Values_With_Syncrhonizer()
+        {
+            var observableCollection = new ObservableCollection<TestObjectWithoutDefaultConstructor>();
+            var newValues = Enumerable.Range(0, 5).ToList();
+            ExecuteAndTestSync(observableCollection, newValues);
+        }
+
+        [Test]
+        public void Synchronizes_Full_Array_With_New_Values()
+        {
+            var observableCollection = new ObservableCollection<TestObjectWithoutDefaultConstructor>()
+                {
+                    new TestObjectWithoutDefaultConstructor("11"),
+                    new TestObjectWithoutDefaultConstructor("12"),
+                    new TestObjectWithoutDefaultConstructor("13")
+                };
+            var newValues = Enumerable.Range(0, 5).ToList();
+            ExecuteAndTestSync(observableCollection, newValues);
+        }
+
+        [Test]
+        public void Synchronizes_Full_Array_With_No_Values()
+        {
+            var observableCollection = new ObservableCollection<TestObjectWithoutDefaultConstructor>()
+                {
+                    new TestObjectWithoutDefaultConstructor("11"),
+                    new TestObjectWithoutDefaultConstructor("12"),
+                    new TestObjectWithoutDefaultConstructor("13")
+                };
+            var newValues = new List<int>();
+            ExecuteAndTestSync(observableCollection, newValues);
+        }
+
+        private static void ExecuteAndTestSync(
+            ObservableCollection<TestObjectWithoutDefaultConstructor> observableCollection,
+            IList<int> newValues
+        )
+        {
+            var originalSize = observableCollection.Count;
+            var changedCount = 0;
+            observableCollection.CollectionChanged += (o, e) => changedCount++;
+            observableCollection.Synchronize(
+                () => new TestObjectWithoutDefaultConstructor(null),
+                (i, to) => to.Value = i.ToString(),
+                newValues
+                );
+            Assert.AreEqual(newValues.Count, observableCollection.Count);
+            Assert.AreEqual(Math.Abs(originalSize - newValues.Count), changedCount);
+            for (var i = 0; i < newValues.Count; i++)
+            {
+                Assert.AreEqual(newValues[i].ToString(), observableCollection[i].Value);
+            }
+        }
+    }
+
+    public class TestObjectWithDefaultConstructor
+    {
+        public string Value { get; set; }
+    }
+
+    public class TestObjectWithoutDefaultConstructor
+    {
+        public TestObjectWithoutDefaultConstructor(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; set; }
+    }
+}

--- a/source/UpbeatUI.Tests/UpbeatUI.Tests.csproj
+++ b/source/UpbeatUI.Tests/UpbeatUI.Tests.csproj
@@ -6,7 +6,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Description>Unit tests for UpbeatUI.</Description>
     <Authors>Michael P. Duda</Authors>

--- a/source/UpbeatUI/ViewModel/ListSynchronize/Extensions.cs
+++ b/source/UpbeatUI/ViewModel/ListSynchronize/Extensions.cs
@@ -1,0 +1,132 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UpbeatUI.ViewModel.ListSynchronize
+{
+    public static class Extensions
+    {
+        public static void Synchronize<TSyncable>(
+            this IList<TSyncable> items,
+            params IEnumerable<TSyncable>[] sources
+        )
+        {
+            var list = sources.SelectMany(a => a).ToList();
+            int count = items.Count;
+            for (int i = 0; i < Math.Max(list.Count, count); i++)
+            {
+                if (i >= count)
+                {
+                    items.Add(list[i]);
+                }
+                else if (i >= list.Count)
+                    items.RemoveAt(items.Count - 1);
+                else
+                    items[i] = list[i];
+            }
+        }
+
+        public static void Synchronize<TSource, TSyncable>(
+            this IList<TSyncable> items,
+            Action<TSource, TSyncable> synchronizer,
+            params IEnumerable<TSource>[] sources
+        ) where TSyncable : class, new()
+        {
+            items.Synchronize(
+                () => new TSyncable(),
+                synchronizer,
+                sources
+            );
+        }
+
+        public static void Synchronize<TSource, TSyncable>(
+            this IList<TSyncable> items,
+            Func<TSyncable> blankCreator,
+            Action<TSource, TSyncable> synchronizer,
+            params IEnumerable<TSource>[] sources
+        ) where TSyncable : class
+        {
+            items.Synchronize(
+                s =>
+                {
+                    var p = blankCreator();
+                    synchronizer(s, p);
+                    return p;
+                }, synchronizer, sources);
+        }
+
+        public static void Synchronize<TSource, TSyncable>(
+            this IList<TSyncable> items,
+            Func<TSource, TSyncable> creator,
+            Action<TSource, TSyncable> synchronizer,
+            params IEnumerable<TSource>[] sources
+        ) where TSyncable : class
+        {
+            var list = sources.SelectMany(a => a).ToList();
+            int count = items.Count;
+            for (int i = 0; i < Math.Max(list.Count, count); i++)
+            {
+                if (i >= count)
+                {
+                    items.Add(creator(list[i]));
+                }
+                else if (i >= list.Count)
+                    items.RemoveAt(items.Count - 1);
+                else
+                    synchronizer(list[i], items[i]);
+            }
+        }
+    }
+
+    // public class SynchronizableCollection<TSyncable, TSource> : ObservableCollection<TSyncable>
+    // {
+    //     private Func<TSyncable> _blankCreator;
+    //     private Func<TSource, TSyncable> _initializedCreator;
+    //     private Action<TSource, TSyncable> _synchronizer;
+
+    //     public SynchronizableCollection(Action<TSource, TSyncable> synchronizer)
+    //     {
+    //         if (typeof(TSyncable).GetConstructor(Type.EmptyTypes) == null)
+    //             throw new Exception("Type of " + typeof(TSyncable).FullName + " does not provide a default constructor.");
+    //         _synchronizer = synchronizer;
+    //     }
+
+    //     public SynchronizableCollection(Func<TSyncable> blankCreator, Action<TSource, TSyncable> synchronizer)
+    //     {
+    //         _blankCreator = blankCreator;
+    //         _synchronizer = synchronizer;
+    //     }
+
+    //     public SynchronizableCollection(Func<TSource, TSyncable> initializedCreator, Action<TSource, TSyncable> synchronizer)
+    //     {
+    //         _synchronizer = synchronizer;
+    //         _initializedCreator = initializedCreator;
+    //     }
+
+    //     public void Synchronize(params IEnumerable<TSource>[] sources)
+    //     {
+    //         var list = sources.SelectMany(a => a).ToList();
+    //         int count = Count;
+    //         for (int i = 0; i < Math.Max(list.Count, count); i++)
+    //         {
+    //             if (i >= count)
+    //             {
+    //                 Add(
+    //                     _blankCreator != null ? _blankCreator()
+    //                     : _initializedCreator != null ? _initializedCreator(list[i])
+    //                     : (TSyncable)typeof(TSyncable).GetConstructor(Type.EmptyTypes).Invoke(null));
+    //                 if (_initializedCreator == null)
+    //                     _synchronizer(list[i], this[i]);
+    //             }
+    //             else if (i >= list.Count)
+    //                 RemoveAt(Count - 1);
+    //             else
+    //                 _synchronizer(list[i], this[i]);
+    //         }
+    //     }
+    // }
+}

--- a/source/UpbeatUI/ViewModel/SynchronizableCollection.cs
+++ b/source/UpbeatUI/ViewModel/SynchronizableCollection.cs
@@ -9,6 +9,7 @@ using System.Linq;
 
 namespace UpbeatUI.ViewModel
 {
+    [Obsolete("'SynchronizableCollection' class is deprecated and will be removed in the next major release; use the 'UpbeatUI.ViewModel.SynchronizeCollection' extension methods for the Collection class instead.}")]
     public class SynchronizableCollection<TSyncable> : ObservableCollection<TSyncable>
     {
         public void Synchronize(params IEnumerable<TSyncable>[] sources)
@@ -69,6 +70,7 @@ namespace UpbeatUI.ViewModel
         }
     }
 
+    [Obsolete("'SynchronizableCollection' class is deprecated and will be removed in the next major release; use the 'UpbeatUI.ViewModel.SynchronizeCollection' extension methods for the Collection class instead.}")]
     public class SynchronizableCollection<TSyncable, TSource> : ObservableCollection<TSyncable>
     {
         private Func<TSyncable> _blankCreator;


### PR DESCRIPTION
1. Marks the existing `SynchronizableCollection` classes as deprecated.
2. Creates extension methods for synchronizing lists (which `ObservableCollection` inherits from).
3. Writes tests to ensure syncing works, and that `CollectionChanged` events are fired.
4. Updates usage of `.Synchronize` in the samples.