### PR TITLE
Fixes focus behavior

### DIFF
--- a/source/UpbeatUI/View/BlurredZPanel.cs
+++ b/source/UpbeatUI/View/BlurredZPanel.cs
@@ -116,6 +116,17 @@ namespace UpbeatUI.View
                     _button.Arrange(new Rect(0, 0, arrangeBounds.Width, arrangeBounds.Height));
                 }
                 Children[i].Arrange(new Rect(0, 0, arrangeBounds.Width, arrangeBounds.Height));
+                if (i < Children.Count - 1)
+                {
+                    FocusManager.SetIsFocusScope(Children[i], false);
+                    KeyboardNavigation.SetTabNavigation(Children[i], KeyboardNavigationMode.None);
+                }
+                else
+                {
+                    FocusManager.SetIsFocusScope(Children[i], true);
+                    FocusManager.SetFocusedElement(Children[i], Children[i]);
+                    KeyboardNavigation.SetTabNavigation(Children[i], KeyboardNavigationMode.Local);
+                }
             }
             return arrangeBounds;
         }
@@ -180,10 +191,12 @@ namespace UpbeatUI.View
                  {
                      Background = BlurColor,
                      BorderBrush = BlurColor,
+                     Focusable = false,
                  };
                 _button = new Button()
                 {
                     Opacity = 0.0,
+                    Focusable = false,
                 };
                 BindingOperations.SetBinding(
                     _button, ButtonBase.CommandProperty, new Binding()

--- a/source/UpbeatUI/View/UpbeatControl.cs
+++ b/source/UpbeatUI/View/UpbeatControl.cs
@@ -63,10 +63,15 @@ namespace UpbeatUI.View
                 typeof(UpbeatControl),
                 new PropertyMetadata(0.5));
 
-        static UpbeatControl() =>
+        static UpbeatControl()
+        {
             DefaultStyleKeyProperty.OverrideMetadata(
                 typeof(UpbeatControl),
                 new FrameworkPropertyMetadata(typeof(UpbeatControl)));
+            FocusableProperty.OverrideMetadata(
+                typeof(UpbeatControl),
+                new FrameworkPropertyMetadata(false));
+        }
 
         /// <summary>
         /// Gets or sets the percentage of available height that the content should fill. Can provide one or two values (minimum and maximum). Values can be in percent format (e.g, '50%') or as decimals between 0.0 and 1.0.

--- a/source/UpbeatUI/View/UpbeatStackControl.xaml
+++ b/source/UpbeatUI/View/UpbeatStackControl.xaml
@@ -11,7 +11,8 @@
     <UserControl.Resources>
         <uvc:UpbeatViewSelector x:Key="UpbeatViewSelector" />
     </UserControl.Resources>
-    <ItemsControl ItemsSource="{Binding ViewModels}">
+    <ItemsControl ItemsSource="{Binding ViewModels}"
+                  Focusable="False">
         <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
                 <uv:BlurredZPanel ClosePopupCommand="{Binding RemoveTopViewModelCommand}"
@@ -22,8 +23,8 @@
         <ItemsControl.ItemTemplate>
             <ItemContainerTemplate>
                 <ContentControl ContentTemplateSelector="{StaticResource UpbeatViewSelector}"
-                                Content="{Binding .}">
-                </ContentControl>
+                                Content="{Binding .}"
+                                Focusable="False" />
             </ItemContainerTemplate>
         </ItemsControl.ItemTemplate>
     </ItemsControl>


### PR DESCRIPTION
Implements better control of focus scopes so that only elements in the top control on the `UpbeatStackControl` will be focusable.