### PR TITLE
Deprecates the ActionDeferrer class

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Please see the separate [How To Use](HOW-TO-USE.md) markdown file for a guide to
 
 - Publish new major release with deprecated classes and methods fully removed.
 - Remove the [`UpbeatControl`](source\UpbeatUI\View\UpbeatControl.cs) entirely, and rely on [`<DataTemplate DataType="{x:Type ...}">`](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/data/data-templating-overview#the-datatype-property) instead to match _ViewModel_ instances on the [`UpbeatStack`](source\UpbeatUI\ViewModel\UpbeatStack.cs) with _Views_. Also, re-implement the percentage size and position behavior as a [WPF Decorator](https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.decorator).
-- Deprecate the public [`ActionDeferrer`](source\UpbeatUI\ViewModel\ActionDeferrer.cs) (and move all functionality to [`UpbeatStack.UpbeatServiceDeferrer`](source\UpbeatUI\ViewModel\UpbeatStack.UpbeatServiceDeferrer.cs)).
 - Simplify [`HostedUpbeatBuilder`](source\UpbeatUI.Extensions.Hosting\HostedUpbeatBuilder.cs), [`HostedUpbeatSerivce`](source\UpbeatUI.Extensions.Hosting\HostedUpbeatService.cs), [`UpbeatApplicationService`](source\UpbeatUI.Extensions.Hosting\UpbeatApplicationService.cs), and [`ConfigureUpbeatHost`](source/UpbeatUI.Extensions.Hosting/Extensions.cs#L22) implementations.
 - Write more tests.
 - Execute tests via GitHub Actions.
@@ -50,7 +49,10 @@ Please see the separate [How To Use](HOW-TO-USE.md) markdown file for a guide to
 - Write and [add README files](https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/) for NuGet packages.
 - Add [MAUI](https://github.com/dotnet/maui), [UWP](https://learn.microsoft.com/en-us/windows/uwp/), and/or [WinUI 3](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/) support.
 - Cleanup/improve [`.editorconfig` file](.editorconfig) and format all source files.
-<!-- - Cleanup/improve [`.gitignore` file](.gitignore) (too many unnecessary items listed). -->
+<!--
+- Cleanup/improve [`.gitignore` file](.gitignore) (too many unnecessary items listed).
+- Deprecate the public [`ActionDeferrer`](source\UpbeatUI\ViewModel\ActionDeferrer.cs) (and move all functionality to [`UpbeatStack.UpbeatServiceDeferrer`](source\UpbeatUI\ViewModel\UpbeatStack.UpbeatServiceDeferrer.cs)).
+-->
 
 ## Contributing
 

--- a/source/UpbeatUI/ViewModel/ActionDeferrer.cs
+++ b/source/UpbeatUI/ViewModel/ActionDeferrer.cs
@@ -10,6 +10,7 @@ namespace UpbeatUI.ViewModel
     /// <summary>
     /// Provides functionality to queue up <see cref="Action"/>s and execute them upon disposal.
     /// </summary>
+    [Obsolete("'ActionDeferrer' class is deprecated and will be removed in the next major release.")]
     public class ActionDeferrer : IDisposable
     {
         private Queue<Action> _queue = new Queue<Action>();

--- a/source/UpbeatUI/ViewModel/BaseViewModel.cs
+++ b/source/UpbeatUI/ViewModel/BaseViewModel.cs
@@ -14,7 +14,7 @@ namespace UpbeatUI.ViewModel
     /// <summary>
     /// Provides a base class with convenience methods for ViewModels.
     /// </summary>
-    [Obsolete("'BaseViewModel' abstract class is deprecated and will be removed in the next major release; consider using the 'CommunityToolkit.Mvvm' NuGet package and 'ObservableObject' class instead.}")]
+    [Obsolete("'BaseViewModel' abstract class is deprecated and will be removed in the next major release; consider using the 'CommunityToolkit.Mvvm' NuGet package and 'ObservableObject' class instead.")]
     public abstract class BaseViewModel : INotifyPropertyChanged
     {
         private static readonly Dictionary<string, PropertyChangedEventArgs> _eventArgCache = new Dictionary<string, PropertyChangedEventArgs>();

--- a/source/UpbeatUI/ViewModel/DelegateCommand.cs
+++ b/source/UpbeatUI/ViewModel/DelegateCommand.cs
@@ -11,7 +11,7 @@ namespace UpbeatUI.ViewModel
     /// <summary>
     /// Provides a convenient means of creating an <see cref="ICommand"/> using delegates provided by the parent class.
     /// </summary>
-    [Obsolete("'DelegateCommand' class is deprecated and will be removed in the next major release; consider using the 'CommunityToolkit.Mvvm' NuGet package and 'RelayCommand' class instead.}")]
+    [Obsolete("'DelegateCommand' class is deprecated and will be removed in the next major release; consider using the 'CommunityToolkit.Mvvm' NuGet package and 'RelayCommand' class instead.")]
     public sealed class DelegateCommand : ICommand
     {
         private readonly Action _execute;
@@ -108,7 +108,7 @@ namespace UpbeatUI.ViewModel
     /// Provides a convenient means of creating an <see cref="ICommand"/> with a parameter using delegates provided by the parent class.
     /// </summary>
     /// <typeparam name="T">The type of the command's parameter.</typeparam>
-    [Obsolete("'DelegateCommand<T>' class is deprecated and will be removed in the next major release; consider using the 'CommunityToolkit.Mvvm' NuGet package and 'RelayCommand<T>' class instead.}")]
+    [Obsolete("'DelegateCommand<T>' class is deprecated and will be removed in the next major release; consider using the 'CommunityToolkit.Mvvm' NuGet package and 'RelayCommand<T>' class instead.")]
     public sealed class DelegateCommand<T> : ICommand
     {
         private readonly Action<T> _execute;

--- a/source/UpbeatUI/ViewModel/IUpbeatService.cs
+++ b/source/UpbeatUI/ViewModel/IUpbeatService.cs
@@ -49,21 +49,21 @@ namespace UpbeatUI.ViewModel
         /// Sets the delegate that the containing <see cref="UpbeatStack"/> will call before closing this ViewModel (instead of closing it automatically). The delegate should return true if okay to close and false if the ViewModel needs to stay open.
         /// </summary>
         /// <param name="okToCloseCallback">The delegate that the containing <see cref="UpbeatStack"/> will call before closing this ViewModel. The delegate should return true if okay to close and false if the ViewModel needs to stay open.</param>
-        [Obsolete("Method has been renamed to 'RegisterCloseCallback' which better describes how the UpbeatStack handles multiple okToCloseCallback. The 'SetCloseCallback' method will be removed in UpbeatUI 5.0.0.")]
+        [Obsolete("Method has been renamed to 'RegisterCloseCallback' which better describes how the UpbeatStack handles multiple okToCloseCallback. The 'SetCloseCallback' method will be removed in the next major release.")]
         void SetCloseCallback(Func<bool> okToCloseCallback);
 
         /// <summary>
         /// Sets the async delegate that the containing <see cref="UpbeatStack"/> will before closing this ViewModel (instead of closing it automatically). The async delegate should return true if okay to close and false if the ViewModel needs to stay open.
         /// </summary>
         /// <param name="asyncOkToCloseCallback">The async delegate that the containing <see cref="UpbeatStack"/> will call before closing this ViewModel. The async delegate should return true if okay to close and false if the ViewModel needs to stay open.</param>
-        [Obsolete("Method has been renamed to 'RegisterCloseCallback' which better describes how the UpbeatStack handles multiple asyncOkToCloseCallback. The 'SetCloseCallback' method will be removed in UpbeatUI 5.0.0.")]
+        [Obsolete("Method has been renamed to 'RegisterCloseCallback' which better describes how the UpbeatStack handles multiple asyncOkToCloseCallback. The 'SetCloseCallback' method will be removed in the next major release.")]
         void SetCloseCallback(Func<Task<bool>> asyncOkToCloseCallback);
 
         /// <summary>
         /// Sets the delegate that the containing <see cref="UpbeatStack"/> will call on each frame render IF it is configured to do so. Call <see cref="UpdatesOnRender"/> to find out if this callback will be executed..
         /// </summary>
         /// <param name="updateCallback">THe delegate that the containing <see cref="UpbeatStack"/> will call on each frame render IF it is configured to do so. This delegate should execute as quickly as possible, otherwise it will affect UI responsiveness for the user.</param>
-        [Obsolete("Method has been renamed to 'RegisterUpdateCallback' which better describes how the UpbeatStack handles multiple updateCallbacks. The 'SetUpdateCallback' method will be removed in UpbeatUI 5.0.0.")]
+        [Obsolete("Method has been renamed to 'RegisterUpdateCallback' which better describes how the UpbeatStack handles multiple updateCallbacks. The 'SetUpdateCallback' method will be removed in the next major release.")]
         void SetUpdateCallback(Action updateCallback);
     }
 }

--- a/source/UpbeatUI/ViewModel/UpbeatStack.UpbeatService.cs
+++ b/source/UpbeatUI/ViewModel/UpbeatStack.UpbeatService.cs
@@ -67,15 +67,15 @@ namespace UpbeatUI.ViewModel
             public void RegisterUpdateCallback(Action updateCallback) =>
                 _updateCallbacks.Add(updateCallback);
 
-            [Obsolete("Method has been renamed to 'RegisterCloseCallback' which better describes how the UpbeatStack handles multiple okToCloseCallback. The 'SetCloseCallback' method will be removed in UpbeatUI 5.0.0.")]
+            [Obsolete("Method has been renamed to 'RegisterCloseCallback' which better describes how the UpbeatStack handles multiple okToCloseCallback. The 'SetCloseCallback' method will be removed in the next major release.")]
             public void SetCloseCallback(Func<bool> okToCloseCallback) =>
                 RegisterCloseCallback(okToCloseCallback);
 
-            [Obsolete("Method has been renamed to 'RegisterCloseCallback' which better describes how the UpbeatStack handles multiple asyncOkToCloseCallback. The 'SetCloseCallback' method will be removed in UpbeatUI 5.0.0.")]
+            [Obsolete("Method has been renamed to 'RegisterCloseCallback' which better describes how the UpbeatStack handles multiple asyncOkToCloseCallback. The 'SetCloseCallback' method will be removed in the next major release.")]
             public void SetCloseCallback(Func<Task<bool>> asyncOkToCloseCallback) =>
                 RegisterCloseCallback(asyncOkToCloseCallback);
 
-            [Obsolete("Method has been renamed to 'RegisterUpdateCallback' which better describes how the UpbeatStack handles multiple updateCallbacks. The 'SetUpdateCallback' method will be removed in UpbeatUI 5.0.0.")]
+            [Obsolete("Method has been renamed to 'RegisterUpdateCallback' which better describes how the UpbeatStack handles multiple updateCallbacks. The 'SetUpdateCallback' method will be removed in the next major release.")]
             public void SetUpdateCallback(Action updateCallback) =>
                 RegisterUpdateCallback(updateCallback);
 

--- a/source/UpbeatUI/ViewModel/UpbeatStack.UpbeatServiceDeferrer.cs
+++ b/source/UpbeatUI/ViewModel/UpbeatStack.UpbeatServiceDeferrer.cs
@@ -3,16 +3,34 @@
  * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
  */
 using System;
+using System.Collections.Generic;
 
 namespace UpbeatUI.ViewModel
 {
     public partial class UpbeatStack
     {
-        private class UpbeatServiceDeferrer : ActionDeferrer
+        private class UpbeatServiceDeferrer : IDisposable
         {
+            private readonly Queue<Action> _queue = new Queue<Action>();
+            private readonly Action _unlocker;
+
             public UpbeatServiceDeferrer(UpbeatService configurationService)
-                : base(configurationService.Lock, configurationService.Unlock)
-            { }
+            {
+                if (configurationService == null)
+                    throw new ArgumentNullException("unlocker action must be provided.");
+                _unlocker = configurationService.Unlock;
+                configurationService.Lock(Defer);
+            }
+
+            public void Dispose()
+            {
+                while (_queue.Count > 0)
+                    _queue.Dequeue()();
+                _unlocker();
+            }
+
+            private void Defer(Action action)
+                => _queue.Enqueue(action);
         }
     }
 }


### PR DESCRIPTION
1. Deprecates the publicly visible `ActionDeferrer` class.
2. Copies the full implementation to the private `UpbeatStack.UpbeatServiceDeferrer`.
3. Also updates other deprecation messages to standard language.