### PR TITLE
Fixes focusable on UpbeatStackControl items

### DIFF
--- a/source/UpbeatUI/View/UpbeatStackControl.xaml
+++ b/source/UpbeatUI/View/UpbeatStackControl.xaml
@@ -20,6 +20,12 @@
                                   BlurRadius="{Binding ElementName=Control, Path=BlurRadius}" />
             </ItemsPanelTemplate>
         </ItemsControl.ItemsPanel>
+        <ItemsControl.ItemContainerStyle>
+            <Style TargetType="ContentPresenter">
+                <Setter Property="Focusable"
+                        Value="False" />
+            </Style>
+        </ItemsControl.ItemContainerStyle>
         <ItemsControl.ItemTemplate>
             <ItemContainerTemplate>
                 <ContentControl ContentTemplateSelector="{StaticResource UpbeatViewSelector}"


### PR DESCRIPTION
Disables `Focusable` on another element within the `UpbeatStackControl` that should not be able to receive focus.