### PR TITLE
Marks the Size/PositionRetreiver approach obsolete

### DIFF
--- a/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
+++ b/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
@@ -21,8 +21,8 @@
     <Copyright>© Michael P. Duda 2020-2024</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!-- Update the following properties when publishing a new Nuget version -->
-    <Version>1.1.4</Version>
-    <PackageValidationBaselineVersion>1.1.3</PackageValidationBaselineVersion>
+    <Version>1.1.5</Version>
+    <PackageValidationBaselineVersion>1.1.4</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -21,8 +21,8 @@
     <Copyright>© Michael P. Duda 2020-2024</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!-- Update the following properties when publishing a new Nuget version -->
-    <Version>3.1.4</Version>
-    <PackageValidationBaselineVersion>3.1.3</PackageValidationBaselineVersion>
+    <Version>3.1.5</Version>
+    <PackageValidationBaselineVersion>3.1.4</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/UpbeatUI/UpbeatUI.csproj
+++ b/source/UpbeatUI/UpbeatUI.csproj
@@ -22,8 +22,8 @@
     <Copyright>© Michael P. Duda 2020-2024</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!-- Update the following properties when publishing a new Nuget version -->
-    <Version>4.1.4</Version>
-    <PackageValidationBaselineVersion>4.1.3</PackageValidationBaselineVersion>
+    <Version>4.1.5</Version>
+    <PackageValidationBaselineVersion>4.1.4</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/UpbeatUI/View/AttachedSizeAndPosition.cs
+++ b/source/UpbeatUI/View/AttachedSizeAndPosition.cs
@@ -8,6 +8,7 @@ using UpbeatUI.ViewModel;
 
 namespace UpbeatUI.View
 {
+    [Obsolete("'AttachedSizeAndPosition' class is deprecated and will be removed in the next major release; consider using the 'PercentPositionWithinUpbeatStackConverter' converter and CommandParameter binding approach to receive to position information instead.")]
     public class AttachedSizeAndPosition
     {
         public static readonly DependencyProperty ContainerProperty =

--- a/source/UpbeatUI/ViewModel/PositionRetriever.cs
+++ b/source/UpbeatUI/ViewModel/PositionRetriever.cs
@@ -8,6 +8,7 @@ using UpbeatUI.View;
 
 namespace UpbeatUI.ViewModel
 {
+    [Obsolete("'PositionRetriever' class is deprecated and will be removed in the next major release; consider using the 'PercentPositionWithinUpbeatStackConverter' converter and CommandParameter binding approach to receive to position information instead.")]
     public class PositionRetriever
     {
         public Point Point => Retriever?.Invoke() ?? throw new InvalidCastException($"This {nameof(PositionRetriever)} has not been bound to an {nameof(AttachedSizeAndPosition.PositionRetrieverProperty)}.");

--- a/source/UpbeatUI/ViewModel/SizeRetriever.cs
+++ b/source/UpbeatUI/ViewModel/SizeRetriever.cs
@@ -8,6 +8,7 @@ using UpbeatUI.View;
 
 namespace UpbeatUI.ViewModel
 {
+    [Obsolete("'SizeRetriever' class is deprecated and will be removed in the next major release; consider using the 'PercentPositionWithinUpbeatStackConverter' converter and CommandParameter binding approach to receive to position information instead.")]
     public class SizeRetriever
     {
         public Size Size => Retriever?.Invoke() ?? throw new InvalidCastException($"This {nameof(SizeRetriever)} has not been bound to an {nameof(AttachedSizeAndPosition.SizeRetrieverProperty)}.");


### PR DESCRIPTION
Marks the old `AttachedSizeAndPosition` approach as obsolete/deprecated. These attached properties allowed _Views_ to bind their size and location within the view area to retriever properties in the _ViewModel_. However, the [`PercentPositionWithinUpbeatStackConverter`](https://github.com/Pulselyre/UpbeatUI/blob/main/source/UpbeatUI/View/Converters/PercentPositionWithinUpbeatStackConverter.cs) is a better approached, [as demonstrated in the samples.](https://github.com/Pulselyre/UpbeatUI/blob/main/samples/HostedUpbeatUISample/View/RandomDataControl.xaml#L49-L51)