### PR TITLE
Fixes click/touch behavior when closing views

### DIFF
--- a/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
+++ b/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
@@ -22,7 +22,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>2.1.0-rc1</Version>
+        <Version>2.1.0</Version>
         <PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 

--- a/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
+++ b/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
@@ -22,8 +22,8 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>2.0.0</Version>
-        <!-- <PackageValidationBaselineVersion>1.1.5</PackageValidationBaselineVersion> -->
+        <Version>2.1.0-rc1</Version>
+        <PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -22,8 +22,8 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>4.0.0</Version>
-        <!-- <PackageValidationBaselineVersion>3.1.5</PackageValidationBaselineVersion> -->
+        <Version>4.1.0-rc1</Version>
+        <PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -22,7 +22,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>4.1.0-rc1</Version>
+        <Version>4.1.0</Version>
         <PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 

--- a/source/UpbeatUI/UpbeatUI.csproj
+++ b/source/UpbeatUI/UpbeatUI.csproj
@@ -23,7 +23,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>5.1.0-rc1</Version>
+        <Version>5.1.0</Version>
         <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 

--- a/source/UpbeatUI/UpbeatUI.csproj
+++ b/source/UpbeatUI/UpbeatUI.csproj
@@ -23,8 +23,8 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>5.0.0</Version>
-        <!-- <PackageValidationBaselineVersion>4.1.5</PackageValidationBaselineVersion> -->
+        <Version>5.1.0-rc1</Version>
+        <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/UpbeatUI/View/ModalPanel.cs
+++ b/source/UpbeatUI/View/ModalPanel.cs
@@ -58,6 +58,7 @@ namespace UpbeatUI.View
                 typeof(ModalPanel));
 
         private Border _border;
+        private bool _isBorderDown;
         private bool _blockingVisualChange;
 
         /// <summary>
@@ -173,7 +174,9 @@ namespace UpbeatUI.View
                             Focusable = false,
                             IsHitTestVisible = true,
                         };
+                        _border.MouseDown += HandleBorderMouseDown;
                         _border.MouseUp += HandleBorderMouseUp;
+                        _border.TouchDown += HandleBorderTouchDown;
                         _border.TouchUp += HandleBorderTouchUp;
                     }
                     else
@@ -192,7 +195,9 @@ namespace UpbeatUI.View
                     }
                     else if (_border != null)
                     {
+                        _border.MouseDown -= HandleBorderMouseDown;
                         _border.MouseUp -= HandleBorderMouseUp;
+                        _border.TouchDown -= HandleBorderTouchDown;
                         _border.TouchUp -= HandleBorderTouchUp;
                         _border = null;
                     }
@@ -201,16 +206,24 @@ namespace UpbeatUI.View
             }
         }
 
+        private void HandleBorderMouseDown(object sender, MouseButtonEventArgs e) => _isBorderDown = true;
+
+        private void HandleBorderTouchDown(object sender, TouchEventArgs e) => _isBorderDown = true;
+
         private void HandleBorderMouseUp(object sender, RoutedEventArgs e)
         {
-            if (ClosePopupCommand?.CanExecute(null) ?? false)
+            if (_isBorderDown)
             {
-                ClosePopupCommand.Execute(null);
+                if (ClosePopupCommand?.CanExecute(null) ?? false)
+                {
+                    ClosePopupCommand.Execute(null);
+                }
+                else
+                {
+                    RaiseEvent(new RoutedEventArgs(RequestPopupCloseEvent));
+                }
             }
-            else
-            {
-                RaiseEvent(new RoutedEventArgs(RequestPopupCloseEvent));
-            }
+            _isBorderDown = false;
         }
 
         private void HandleBorderTouchUp(object sender, TouchEventArgs e)


### PR DESCRIPTION
Fixes click/touch behavior when closing views by ensuring a a `MouseDown` or `TouchDown` was received first. This should prevent inadvertent closures where a new View opens up while the user is already clicking or touching the close area.