### PR TITLE
Improves PercentPositionWithinUpbeatStackConverter implementation

### DIFF
--- a/source/UpbeatUI.Tests/View/Converters/PercentPositionWithinUpbeatStackConverter_Tests.cs
+++ b/source/UpbeatUI.Tests/View/Converters/PercentPositionWithinUpbeatStackConverter_Tests.cs
@@ -1,0 +1,78 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using NUnit.Framework;
+using UpbeatUI.View.Converters;
+using UpbeatUI.ViewModel;
+
+namespace UpbeatUI.Tests.View.Converters.PercentPositionWithinUpbeatStackConverter_Tests
+{
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    public class Convert_Tests
+    {
+        private Button Button { get; set; }
+        private UpbeatStack UpbeatStack { get; set; }
+        private Grid Grid { get; set; }
+        private PercentPositionWithinUpbeatStackConverter Converter { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            Button = new();
+            UpbeatStack = new();
+            Grid = new() { DataContext = UpbeatStack };
+            Converter = new();
+        }
+
+        [Test]
+        public void Returns_Working_Getter_When_UpbeatStack_Is_Ancestor()
+        {
+            _ = Grid.Children.Add(Button);
+            Func<Point> pointGetter = null;
+            Assert.DoesNotThrow(
+                () => pointGetter = (Func<Point>)Converter.Convert(
+                    Button,
+                    typeof(object),
+                    null,
+                    CultureInfo.CurrentCulture));
+            Point point = default;
+            Assert.DoesNotThrow(() => point = pointGetter.Invoke());
+            Assert.AreEqual(double.NaN, point.X);
+            Assert.AreEqual(double.NaN, point.Y);
+        }
+
+        [Test]
+        public void Returns_Working_Getter_When_UpbeatStack_Was_Ancestor()
+        {
+            _ = Grid.Children.Add(Button);
+            Func<Point> pointGetter = null;
+            Assert.DoesNotThrow(
+                () => pointGetter = (Func<Point>)Converter.Convert(
+                    Button,
+                    typeof(object),
+                    null,
+                    CultureInfo.CurrentCulture));
+            Grid.Children.Remove(Button);
+            Point point = default;
+            Assert.DoesNotThrow(() => point = pointGetter.Invoke());
+            Assert.AreEqual(double.NaN, point.X);
+            Assert.AreEqual(double.NaN, point.Y);
+        }
+
+        [Test]
+        public void Throws_When_UpbeatStack_Is_Not_Ancestor() =>
+            Assert.Throws<InvalidOperationException>(
+                () => _ = (Func<Point>)Converter.Convert(
+                    Button,
+                    typeof(object),
+                    null,
+                    CultureInfo.CurrentCulture));
+    }
+}

--- a/source/UpbeatUI.Tests/ViewModel/UpbeatStack_Tests.cs
+++ b/source/UpbeatUI.Tests/ViewModel/UpbeatStack_Tests.cs
@@ -9,6 +9,7 @@ using UpbeatUI.ViewModel;
 
 namespace UpbeatUI.Tests.ViewModel.UpbeatStack_Tests
 {
+    [TestFixture]
     public class BaseFixture
     {
         protected UpbeatStack UpbeatStack { get; set; }
@@ -17,7 +18,7 @@ namespace UpbeatUI.Tests.ViewModel.UpbeatStack_Tests
         protected int EmptiedCount { get; set; }
 
         [SetUp]
-        public void Setuip()
+        public void SetUp()
         {
             UpbeatStack = new UpbeatStack();
             CloseAttemptCount = 0;
@@ -82,11 +83,10 @@ namespace UpbeatUI.Tests.ViewModel.UpbeatStack_Tests
         }
     }
 
-    [TestFixture]
     public class RemoveTopViewModelCommand_Tests : BaseFixture
     {
         [Test]
-        public void AllowsOnlyOneExecution()
+        public void Allows_Only_One_Execution()
         {
             var tcs = new TaskCompletionSource();
             UpbeatStack.OpenViewModel(BuildParameters(tcs), () => ClosedCount++);
@@ -108,31 +108,34 @@ namespace UpbeatUI.Tests.ViewModel.UpbeatStack_Tests
             Assert.AreEqual(1, EmptiedCount);
         }
 
-        [Test]
-        public void CanExecute_Returns_True_When_Not_Executiong()
+        public class CanExecute_Tests : BaseFixture
         {
-            UpbeatStack.OpenViewModel(new TestViewModel.Parameters(), () => ClosedCount++);
-            Assert.IsTrue(UpbeatStack.RemoveTopViewModelCommand.CanExecute(null));
-        }
 
-        [Test]
-        public void CanExecute_Returns_False_When_No_ViewModels() =>
-            Assert.IsFalse(UpbeatStack.RemoveTopViewModelCommand.CanExecute(null));
+            [Test]
+            public void Returns_True_When_Not_Executiong()
+            {
+                UpbeatStack.OpenViewModel(new TestViewModel.Parameters(), () => ClosedCount++);
+                Assert.IsTrue(UpbeatStack.RemoveTopViewModelCommand.CanExecute(null));
+            }
 
-        [Test]
-        public void CanExecute_Returns_False_When_Executiong()
-        {
-            var tcs = new TaskCompletionSource();
-            UpbeatStack.OpenViewModel(BuildParameters(tcs), () => ClosedCount++);
-            UpbeatStack.OpenViewModel(BuildParameters(tcs), () => ClosedCount++);
-            UpbeatStack.RemoveTopViewModelCommand.Execute(null);
-            Assert.IsFalse(UpbeatStack.RemoveTopViewModelCommand.CanExecute(null));
-            tcs.SetResult();
-            Assert.IsTrue(UpbeatStack.RemoveTopViewModelCommand.CanExecute(null));
+            [Test]
+            public void Returns_False_When_No_ViewModels() =>
+                Assert.IsFalse(UpbeatStack.RemoveTopViewModelCommand.CanExecute(null));
+
+            [Test]
+            public void Returns_False_When_Executiong()
+            {
+                var tcs = new TaskCompletionSource();
+                UpbeatStack.OpenViewModel(BuildParameters(tcs), () => ClosedCount++);
+                UpbeatStack.OpenViewModel(BuildParameters(tcs), () => ClosedCount++);
+                UpbeatStack.RemoveTopViewModelCommand.Execute(null);
+                Assert.IsFalse(UpbeatStack.RemoveTopViewModelCommand.CanExecute(null));
+                tcs.SetResult();
+                Assert.IsTrue(UpbeatStack.RemoveTopViewModelCommand.CanExecute(null));
+            }
         }
     }
 
-    [TestFixture]
     public class TryCloseAllViewModelsAsync_Tests : BaseFixture
     {
         [Test]
@@ -168,7 +171,7 @@ namespace UpbeatUI.Tests.ViewModel.UpbeatStack_Tests
         }
 
         [Test]
-        public async Task Waits_For_Already_Closing_ViewModel()
+        public async Task Waits_When_Already_Closing_ViewModel()
         {
             var tcs1 = new TaskCompletionSource();
             var tcs2 = new TaskCompletionSource();

--- a/source/UpbeatUI/View/Converters/PercentPositionWithinUpbeatStackConverter.cs
+++ b/source/UpbeatUI/View/Converters/PercentPositionWithinUpbeatStackConverter.cs
@@ -21,25 +21,25 @@ namespace UpbeatUI.View.Converters
         {
             var containerClass = parameter is null ? typeof(IUpbeatStack) : (Type)parameter;
             var control = value as FrameworkElement;
-            return new Func<Point>(() =>
+            var container = control as DependencyObject;
+            var parent = VisualTreeHelper.GetParent(control);
+            while (!(parent is null))
             {
-                var container = control as DependencyObject;
-                var parent = VisualTreeHelper.GetParent(control);
-                while (!(parent is null))
+                if (parent is FrameworkElement parentElement &&
+                    containerClass.IsAssignableFrom(parentElement.DataContext.GetType()))
                 {
-                    if (parent is FrameworkElement parentElement &&
-                        containerClass.IsAssignableFrom(parentElement.DataContext.GetType()))
+                    return new Func<Point>(() =>
                     {
                         var rawPoint = control.TranslatePoint(new Point(0, 0), parentElement);
                         return new Point(
                             (rawPoint.X + control.ActualWidth / 2.0) / parentElement.ActualWidth,
                             (rawPoint.Y + control.ActualHeight / 2.0) / parentElement.ActualHeight);
-                    }
-                    container = parent;
-                    parent = VisualTreeHelper.GetParent(container);
+                    });
                 }
-                throw new InvalidOperationException($"Unable to locate an ancestor {nameof(IUpbeatStack)} to position within. Reached root element {container}.");
-            });
+                container = parent;
+                parent = VisualTreeHelper.GetParent(container);
+            }
+            throw new InvalidOperationException($"Unable to locate an ancestor {nameof(IUpbeatStack)} to position within. Reached root element {container}.");
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
1. Cleans up tests structure for `UpbeatStack`.
2. Improves the `PercentPositionWithinUpbeatStackConverter` implementation to fail on binding when it cannot find an ancestor control with an `UpbeatStack` as its `DataContext`. This will cause it to fail early rather that only when the `Point` getter `Func` is invoked.