### PR TITLE
Improves UpbeatMainWindow fullscreen view capabilities

### DIFF
--- a/samples/HostedUpbeatUISample/View/MenuTemplate.xaml
+++ b/samples/HostedUpbeatUISample/View/MenuTemplate.xaml
@@ -44,6 +44,9 @@
                     <Button
                         Command="{Binding OpenSharedListCommand}"
                         Margin="5">Shared List</Button>
+                    <ToggleButton
+                        IsChecked="{Binding Fullscreen, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type uv:UpbeatMainWindow}}}"
+                        Margin="5">Fullscreen</ToggleButton>
                     <TextBlock
                         TextAlignment="Center"
                         Margin="5"

--- a/samples/ManualUpbeatUISample/View/MenuTemplate.xaml
+++ b/samples/ManualUpbeatUISample/View/MenuTemplate.xaml
@@ -44,6 +44,9 @@
                     <Button
                         Command="{Binding OpenSharedListCommand}"
                         Margin="5">Shared List</Button>
+                    <ToggleButton
+                        IsChecked="{Binding Fullscreen, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type uv:UpbeatMainWindow}}}"
+                        Margin="5">Fullscreen</ToggleButton>
                     <TextBlock
                         TextAlignment="Center"
                         Margin="5"

--- a/samples/ServiceProvidedUpbeatUISample/View/MenuTemplate.xaml
+++ b/samples/ServiceProvidedUpbeatUISample/View/MenuTemplate.xaml
@@ -44,6 +44,9 @@
                     <Button
                         Command="{Binding OpenSharedListCommand}"
                         Margin="5">Shared List</Button>
+                    <ToggleButton
+                        IsChecked="{Binding Fullscreen, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type uv:UpbeatMainWindow}}}"
+                        Margin="5">Fullscreen</ToggleButton>
                     <TextBlock
                         TextAlignment="Center"
                         Margin="5"

--- a/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
+++ b/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
@@ -22,7 +22,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>2.2.0-rc1</Version>
+        <Version>2.2.0-rc2</Version>
         <PackageValidationBaselineVersion>2.1.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -22,7 +22,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>4.2.0-rc1</Version>
+        <Version>4.2.0-rc2</Version>
         <PackageValidationBaselineVersion>4.1.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 

--- a/source/UpbeatUI/UpbeatUI.csproj
+++ b/source/UpbeatUI/UpbeatUI.csproj
@@ -23,7 +23,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>5.2.0-rc1</Version>
+        <Version>5.2.0-rc2</Version>
         <PackageValidationBaselineVersion>5.1.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 

--- a/source/UpbeatUI/View/UpbeatMainWindow.xaml
+++ b/source/UpbeatUI/View/UpbeatMainWindow.xaml
@@ -14,31 +14,6 @@
     d:DesignHeight="500"
     d:DesignWidth="500">
     <Grid>
-        <Grid.Style>
-            <Style TargetType="Grid">
-                <Setter
-                    Property="Margin"
-                    Value="0" />
-                <Style.Triggers>
-                    <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                            <Condition
-                                Binding="{Binding ElementName=_upbeatMainWindow, Path=ResizeMode}"
-                                Value="NoResize" />
-                            <Condition
-                                Binding="{Binding ElementName=_upbeatMainWindow, Path=WindowState}"
-                                Value="Maximized" />
-                            <Condition
-                                Binding="{Binding ElementName=_upbeatMainWindow, Path=WindowStyle}"
-                                Value="None" />
-                        </MultiDataTrigger.Conditions>
-                        <Setter
-                            Property="Margin"
-                            Value="8" />
-                    </MultiDataTrigger>
-                </Style.Triggers>
-            </Style>
-        </Grid.Style>
         <ItemsControl
             ItemsSource="{Binding ViewModels}"
             Focusable="False">

--- a/source/UpbeatUI/View/UpbeatMainWindow.xaml
+++ b/source/UpbeatUI/View/UpbeatMainWindow.xaml
@@ -14,6 +14,20 @@
     d:DesignHeight="500"
     d:DesignWidth="500">
     <Grid>
+        <Grid.Style>
+            <Style TargetType="Grid">
+                <Setter
+                    Property="Margin"
+                    Value="0" />
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding Fullscreen, ElementName=_upbeatMainWindow}" Value="True">
+                        <Setter
+                            Property="Margin"
+                            Value="{Binding FullscreenContentMargin, ElementName=_upbeatMainWindow}" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </Grid.Style>
         <ItemsControl
             ItemsSource="{Binding ViewModels}"
             Focusable="False">

--- a/source/UpbeatUI/View/UpbeatMainWindow.xaml.cs
+++ b/source/UpbeatUI/View/UpbeatMainWindow.xaml.cs
@@ -24,6 +24,16 @@ namespace UpbeatUI.View
                 new FrameworkPropertyMetadata(false, HandleFullscreenPropertyChanged));
 
         /// <summary>
+        /// Identifies the <see cref="FullscreenContentMargin"/> <see cref="DependencyProperty"/>.
+        /// </summary>
+        public readonly static DependencyProperty FullscreenContentMarginProperty =
+            DependencyProperty.Register(
+                "FullscreenContentMargin",
+                typeof(Thickness),
+                typeof(UpbeatMainWindow),
+                new FrameworkPropertyMetadata(new Thickness(0)));
+
+        /// <summary>
         /// Identifies the <see cref="ModalBackground"/> <see cref="DependencyProperty"/>.
         /// </summary>
         public readonly static DependencyProperty ModalBackgroundProperty =
@@ -52,6 +62,17 @@ namespace UpbeatUI.View
         {
             get => (bool)GetValue(FullscreenProperty);
             set => SetValue(FullscreenProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="UpbeatMainWindow"/>'s content margin when in fullscreen mode.
+        /// <para>Under certain <see cref="Window"/> styling conditions and when in fullscreen mode, the content might be rendered outside the visible area of the screen. This property allows you to counteract that behavior by adding margin to the content to shrink its rendered size (or subtracting margin to increase the rendered size).</para>
+        /// <para>This property has no effect when in windowed (non-fullscreen) mode.</para>
+        /// </summary>
+        public Thickness FullscreenContentMargin
+        {
+            get => (Thickness)GetValue(FullscreenContentMarginProperty);
+            set => SetValue(FullscreenContentMarginProperty, value);
         }
 
         /// <summary>

--- a/source/UpbeatUI/View/UpbeatMainWindow.xaml.cs
+++ b/source/UpbeatUI/View/UpbeatMainWindow.xaml.cs
@@ -14,6 +14,16 @@ namespace UpbeatUI.View
     public partial class UpbeatMainWindow : Window
     {
         /// <summary>
+        /// Identifies the <see cref="Fullscreen"/> <see cref="DependencyProperty"/>.
+        /// </summary>
+        public readonly static DependencyProperty FullscreenProperty =
+            DependencyProperty.Register(
+                "Fullscreen",
+                typeof(bool),
+                typeof(UpbeatMainWindow),
+                new FrameworkPropertyMetadata(false, HandleFullscreenPropertyChanged));
+
+        /// <summary>
         /// Identifies the <see cref="ModalBackground"/> <see cref="DependencyProperty"/>.
         /// </summary>
         public readonly static DependencyProperty ModalBackgroundProperty =
@@ -36,6 +46,15 @@ namespace UpbeatUI.View
             InitializeComponent();
 
         /// <summary>
+        /// Gets or sets whether the <see cref="UpbeatMainWindow"/> is in fullscreen mode or not.
+        /// </summary>
+        public bool Fullscreen
+        {
+            get => (bool)GetValue(FullscreenProperty);
+            set => SetValue(FullscreenProperty, value);
+        }
+
+        /// <summary>
         /// Gets or sets a <see cref="Brush"/> that the <see cref="ModalPanel"/> will show underneath the top (active) Element.
         /// </summary>
         public Brush ModalBackground
@@ -51,6 +70,25 @@ namespace UpbeatUI.View
         {
             get => (BlurEffect)GetValue(ModalBlurEffectProprety);
             set => SetValue(ModalBlurEffectProprety, value);
+        }
+
+        private static void HandleFullscreenPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is UpbeatMainWindow upbeatMainWindow)
+            {
+                if (upbeatMainWindow.Fullscreen)
+                {
+                    upbeatMainWindow.ResizeMode = ResizeMode.NoResize;
+                    upbeatMainWindow.WindowStyle = WindowStyle.None;
+                    upbeatMainWindow.WindowState = WindowState.Maximized;
+                }
+                else
+                {
+                    upbeatMainWindow.WindowState = WindowState.Normal;
+                    upbeatMainWindow.WindowStyle = WindowStyle.SingleBorderWindow;
+                    upbeatMainWindow.ResizeMode = ResizeMode.CanResize;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
1. Adds a `Fullscreen` property to the `UpbeatMainWindow` for convenience. Setting to `true` will change the values of three `Window` properties that in effect render the window in full screen with no title bar, no border, and in front of the task bar.
2. Adds a `FullscreenContentMargin` property to `UpbeatMainWindow` for scenarios where content might be rendered outside the visible area when in fullscreen.
3. Adds fullscreen toggle buttons to the samples.