### PR TITLE
Adds an optional fatal error handler configuration to the Hosted service

### DIFF
--- a/samples/HostedUpbeatUISample/App.xaml.cs
+++ b/samples/HostedUpbeatUISample/App.xaml.cs
@@ -38,7 +38,21 @@ public partial class App : Application
                         ModalBackground = new SolidColorBrush(Brushes.LightGray.Color) { Opacity = 0.5 }, // The brush to display underneath the top View.
                         ModalBlurEffect = new BlurEffect() { Radius = 10.0, KernelType = KernelType.Gaussian }, // The blur effect to apply to Views that are not on top. This is optional, as blur effects can significantly impact performance.
                     })
-                    .SetFatalErrorHandler(e => MessageBox.Show($"Exception: {e.GetType().FullName} {e.Message}")))
+                    .SetFatalErrorHandler(e =>
+                    {
+                        if (MessageBox.Show(
+                            $"Error message: {e.Message}. See stack trace?",
+                            "Fatal Error",
+                            MessageBoxButton.YesNo,
+                            MessageBoxImage.Error) == MessageBoxResult.Yes)
+                        {
+                            _ = MessageBox.Show(
+                                e.StackTrace,
+                                "Fatal Error",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.None);
+                        }
+                    }))
             .Build()
             .RunAsync().ConfigureAwait(true);
 }

--- a/samples/HostedUpbeatUISample/App.xaml.cs
+++ b/samples/HostedUpbeatUISample/App.xaml.cs
@@ -37,7 +37,8 @@ public partial class App : Application
                         WindowStartupLocation = WindowStartupLocation.CenterScreen,
                         ModalBackground = new SolidColorBrush(Brushes.LightGray.Color) { Opacity = 0.5 }, // The brush to display underneath the top View.
                         ModalBlurEffect = new BlurEffect() { Radius = 10.0, KernelType = KernelType.Gaussian }, // The blur effect to apply to Views that are not on top. This is optional, as blur effects can significantly impact performance.
-                    }))
+                    })
+                    .SetFatalErrorHandler(e => MessageBox.Show($"Exception: {e.GetType().FullName} {e.Message}")))
             .Build()
             .RunAsync().ConfigureAwait(true);
 }

--- a/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
+++ b/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
@@ -23,7 +23,7 @@
     <ItemGroup>
         <PackageReference
             Include="UpbeatUI.Extensions.Hosting"
-            Version="4.2.0" />
+            Version="5.0.0-rc1" />
         <!-- Switch from the PackageReference to the ProjectReference to test local UpbeatUI changes in the samples. -->
         <!-- <ProjectReference Include="..\..\source\UpbeatUI.Extensions.Hosting\UpbeatUI.Extensions.Hosting.csproj" /> -->
     </ItemGroup>

--- a/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
+++ b/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
@@ -17,13 +17,13 @@
             Version="8.2.*" />
         <PackageReference
             Include="Microsoft.Extensions.Hosting"
-            Version="3.1.9" />
+            Version="7.0.1" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference
             Include="UpbeatUI.Extensions.Hosting"
-            Version="5.0.0-rc1" />
+            Version="5.0.0-rc2" />
         <!-- Switch from the PackageReference to the ProjectReference to test local UpbeatUI changes in the samples. -->
         <!-- <ProjectReference Include="..\..\source\UpbeatUI.Extensions.Hosting\UpbeatUI.Extensions.Hosting.csproj" /> -->
     </ItemGroup>

--- a/samples/ManualUpbeatUISample/App.xaml.cs
+++ b/samples/ManualUpbeatUISample/App.xaml.cs
@@ -24,11 +24,11 @@ public partial class App : Application
 
     private async void HandleApplicationStartup(object sender, StartupEventArgs e)
     {
-        {
-            using var sharedTimer = new SharedTimer();
+        using var sharedTimer = new SharedTimer();
 
-            // The UpbeatStack is the central data structure for an UpbeatUI app. One must be created for the life of the application and should be disposed at the end.
-            using var upbeatStack = new UpbeatStack();
+        // The UpbeatStack is the central data structure for an UpbeatUI app. One must be created for the life of the application and should be disposed at the end.
+        using (var upbeatStack = new UpbeatStack())
+        {
 
             // The UpbeatStack depends on mappings of Parameters types to ViewModels and controls to determine which ViewModel to create and which View to show. Without an IServiceProvider, you must manually map each Parameters, ViewModel, and View type, along with a constructur the IUpbeatStack can call to create a ViewModel.
             upbeatStack.MapViewModel<BottomViewModel.Parameters, BottomViewModel>(
@@ -121,7 +121,18 @@ public partial class App : Application
         }
         if (_exception is not null)
         {
-            _ = MessageBox.Show($"Exception: {_exception.GetType().FullName} {_exception.Message}");
+            if (MessageBox.Show(
+                $"Error message: {_exception.Message}. See stack trace?",
+                "Fatal Error",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Error) == MessageBoxResult.Yes)
+            {
+                _ = MessageBox.Show(
+                    _exception.StackTrace,
+                    "Fatal Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.None);
+            }
         }
     }
 }

--- a/samples/ManualUpbeatUISample/App.xaml.cs
+++ b/samples/ManualUpbeatUISample/App.xaml.cs
@@ -12,6 +12,7 @@ using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Security.Cryptography;
 using System.Windows.Media.Effects;
+using System.Windows.Threading;
 
 namespace ManualUpbeatUISample;
 
@@ -19,84 +20,109 @@ public partial class App : Application
 {
     // This app would like to provide a way for the user to cancel exiting. To do so, we create a shared task that can be triggered and reset.
     private TaskCompletionSource _closeRequestedTask = new();
+    private Exception _exception;
 
     private async void HandleApplicationStartup(object sender, StartupEventArgs e)
     {
-        using var sharedTimer = new SharedTimer();
+        {
+            using var sharedTimer = new SharedTimer();
 
-        // The UpbeatStack is the central data structure for an UpbeatUI app. One must be created for the life of the application and should be disposed at the end.
-        using var upbeatStack = new UpbeatStack();
+            // The UpbeatStack is the central data structure for an UpbeatUI app. One must be created for the life of the application and should be disposed at the end.
+            using var upbeatStack = new UpbeatStack();
 
-        // The UpbeatStack depends on mappings of Parameters types to ViewModels and controls to determine which ViewModel to create and which View to show. Without an IServiceProvider, you must manually map each Parameters, ViewModel, and View type, along with a constructur the IUpbeatStack can call to create a ViewModel.
-        upbeatStack.MapViewModel<BottomViewModel.Parameters, BottomViewModel>(
-            (service, parameters) => new BottomViewModel(service, sharedTimer));
-        upbeatStack.MapViewModel<ConfirmPopupViewModel.Parameters, ConfirmPopupViewModel>(
-            (upbeatService, parameters) => new ConfirmPopupViewModel(upbeatService, parameters, sharedTimer));
+            // The UpbeatStack depends on mappings of Parameters types to ViewModels and controls to determine which ViewModel to create and which View to show. Without an IServiceProvider, you must manually map each Parameters, ViewModel, and View type, along with a constructur the IUpbeatStack can call to create a ViewModel.
+            upbeatStack.MapViewModel<BottomViewModel.Parameters, BottomViewModel>(
+                (service, parameters) => new BottomViewModel(service, sharedTimer));
+            upbeatStack.MapViewModel<ConfirmPopupViewModel.Parameters, ConfirmPopupViewModel>(
+                (upbeatService, parameters) => new ConfirmPopupViewModel(upbeatService, parameters, sharedTimer));
 
-        // The MenuViewModel's constructor requires an Action that it can use to start closing the application. We will provide the shared _closeRequestedTask's TrySetResult() method to indicate the user has requested to close the application.
-        upbeatStack.MapViewModel<MenuViewModel.Parameters, MenuViewModel>(
-            (upbeatService, parameters) => new MenuViewModel(upbeatService, () => _closeRequestedTask.TrySetResult(), sharedTimer));
-        upbeatStack.MapViewModel<PopupViewModel.Parameters, PopupViewModel>(
-            (upbeatService, parameters) => new PopupViewModel(parameters, sharedTimer));
-        upbeatStack.MapViewModel<RandomDataViewModel.Parameters, RandomDataViewModel>(
-            (upbeatService, parameters) => new RandomDataViewModel(upbeatService, RandomNumberGenerator.Create(), sharedTimer));
-        upbeatStack.MapViewModel<SharedListViewModel.Parameters, SharedListViewModel>(
-            (upbeatService, parameters) =>
+            // The MenuViewModel's constructor requires an Action that it can use to start closing the application. We will provide the shared _closeRequestedTask's TrySetResult() method to indicate the user has requested to close the application.
+            upbeatStack.MapViewModel<MenuViewModel.Parameters, MenuViewModel>(
+                (upbeatService, parameters) => new MenuViewModel(upbeatService, () => _closeRequestedTask.TrySetResult(), sharedTimer));
+            upbeatStack.MapViewModel<PopupViewModel.Parameters, PopupViewModel>(
+                (upbeatService, parameters) => new PopupViewModel(parameters, sharedTimer));
+            upbeatStack.MapViewModel<RandomDataViewModel.Parameters, RandomDataViewModel>(
+                (upbeatService, parameters) => new RandomDataViewModel(upbeatService, RandomNumberGenerator.Create(), sharedTimer));
+            upbeatStack.MapViewModel<SharedListViewModel.Parameters, SharedListViewModel>(
+                (upbeatService, parameters) =>
+                {
+                    // The SharedListViewModel shares an IUpbeatService and scoped SharedList service with its child ViewModel, the SharedListDataViewModel. The scoped service can be manually created and provided to both.
+                    var sharedList = new SharedList();
+                    return new SharedListViewModel(upbeatService, sharedList, sharedTimer,
+                        new SharedListDataViewModel(upbeatService, sharedList));
+                });
+            upbeatStack.MapViewModel<TextEntryPopupViewModel.Parameters, TextEntryPopupViewModel>(
+                (upbeatService, parameters) => new TextEntryPopupViewModel(upbeatService, parameters, sharedTimer));
+
+            // The included UpdateMainWindow class already provides the necessary controls to display Views for ViewModels when an IUpbeatStack is set as the DataContext.
+            var mainWindow = new UpbeatMainWindow()
             {
-                // The SharedListViewModel shares an IUpbeatService and scoped SharedList service with its child ViewModel, the SharedListDataViewModel. The scoped service can be manually created and provided to both.
-                var sharedList = new SharedList();
-                return new SharedListViewModel(upbeatService, sharedList, sharedTimer,
-                    new SharedListDataViewModel(upbeatService, sharedList));
-            });
-        upbeatStack.MapViewModel<TextEntryPopupViewModel.Parameters, TextEntryPopupViewModel>(
-            (upbeatService, parameters) => new TextEntryPopupViewModel(upbeatService, parameters, sharedTimer));
+                // You must set the DataContext to the UpbeatStack.
+                DataContext = upbeatStack,
+                Title = "UpbeatUI Sample Application",
+                MinHeight = 275,
+                MinWidth = 275,
+                Height = 400,
+                Width = 400,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen,
+                ModalBackground = new SolidColorBrush(Brushes.LightGray.Color) { Opacity = 0.5 }, // The brush to display underneath the top View.
+                ModalBlurEffect = new BlurEffect() { Radius = 10.0, KernelType = KernelType.Gaussian }, // The blur effect to apply to Views that are not on top. This is optional, as blur effects can significantly impact performance.
+            };
 
-        // The included UpdateMainWindow class already provides the necessary controls to display Views for ViewModels when an IUpbeatStack is set as the DataContext.
-        var mainWindow = new UpbeatMainWindow()
-        {
-            // You must set the DataContext to the UpbeatStack.
-            DataContext = upbeatStack,
-            Title = "UpbeatUI Sample Application",
-            MinHeight = 275,
-            MinWidth = 275,
-            Height = 400,
-            Width = 400,
-            WindowStartupLocation = WindowStartupLocation.CenterScreen,
-            ModalBackground = new SolidColorBrush(Brushes.LightGray.Color) { Opacity = 0.5 }, // The brush to display underneath the top View.
-            ModalBlurEffect = new BlurEffect() { Radius = 10.0, KernelType = KernelType.Gaussian }, // The blur effect to apply to Views that are not on top. This is optional, as blur effects can significantly impact performance.
-        };
-
-        // Override the default Window Closing event to request a close instead of immediately closing itself.
-        void HandleMainWindowClosing(object sender, CancelEventArgs e)
-        {
-            e.Cancel = true;
-            _ = _closeRequestedTask.TrySetResult();
-        }
-        mainWindow.Closing += HandleMainWindowClosing;
-        // When the UpbeatStack has no more view models, the 'ViewModelsEmptied' event will be triggered, so we can count that as a request to close the application.
-        void HandleUpbeatStackEmpied(object sender, EventArgs e) => _closeRequestedTask.TrySetResult();
-        upbeatStack.ViewModelsEmptied += HandleUpbeatStackEmpied;
-
-        // Add a base BottomViewModel to the UpbeatStack.
-        upbeatStack.OpenViewModel(new BottomViewModel.Parameters());
-
-        // We are now ready to show the main window.
-        mainWindow.Show();
-
-        // We set up an infinite loop to await the shared _closeRequestedTask, then attempt to close all ViewModels. If successful, we can exit the application. If not successful, possibly because the user cancelled closing, then reset the shared task and await again.
-        while (true)
-        {
-            await _closeRequestedTask.Task.ConfigureAwait(true);
-            if (await upbeatStack.TryCloseAllViewModelsAsync().ConfigureAwait(true))
+            // Override the default Window Closing event to request a close instead of immediately closing itself.
+            void HandleMainWindowClosing(object sender, CancelEventArgs e)
             {
-                break;
+                e.Cancel = true;
+                _ = _closeRequestedTask.TrySetResult();
             }
-            _closeRequestedTask = new TaskCompletionSource();
-        }
+            mainWindow.Closing += HandleMainWindowClosing;
+            // When the UpbeatStack has no more view models, the 'ViewModelsEmptied' event will be triggered, so we can count that as a request to close the application.
+            void HandleUpbeatStackEmpied(object sender, EventArgs e) => _closeRequestedTask.TrySetResult();
+            // Add a mechanism to catch unhandled exceptions.
+            upbeatStack.ViewModelsEmptied += HandleUpbeatStackEmpied;
+            void HandleApplicationException(object sender, DispatcherUnhandledExceptionEventArgs e)
+            {
+                e.Handled = true;
+                _exception = e.Exception;
+                _ = _closeRequestedTask.TrySetException(e.Exception);
+            }
+            Current.DispatcherUnhandledException += HandleApplicationException;
 
-        upbeatStack.ViewModelsEmptied -= HandleUpbeatStackEmpied;
-        mainWindow.Closing -= HandleMainWindowClosing;
-        mainWindow.Close();
+            try
+            {
+                // Add a base BottomViewModel to the UpbeatStack.
+                upbeatStack.OpenViewModel(new BottomViewModel.Parameters());
+
+                // We are now ready to show the main window.
+                mainWindow.Show();
+
+                // We set up an infinite loop to await the shared _closeRequestedTask, then attempt to close all ViewModels. If successful, we can exit the application. If not successful, possibly because the user cancelled closing, then reset the shared task and await again.
+                while (true)
+                {
+                    await _closeRequestedTask.Task.ConfigureAwait(true);
+                    if (await upbeatStack.TryCloseAllViewModelsAsync().ConfigureAwait(true))
+                    {
+                        break;
+                    }
+                    _closeRequestedTask = new TaskCompletionSource();
+                }
+            }
+            catch (Exception ex)
+            {
+                _exception ??= ex;
+            }
+            finally
+            {
+                Current.DispatcherUnhandledException -= HandleApplicationException;
+                upbeatStack.ViewModelsEmptied -= HandleUpbeatStackEmpied;
+                mainWindow.Closing -= HandleMainWindowClosing;
+                mainWindow.Close();
+            }
+        }
+        if (_exception is not null)
+        {
+            _ = MessageBox.Show($"Exception: {_exception.GetType().FullName} {_exception.Message}");
+        }
     }
 }
 

--- a/samples/ServiceProvidedUpbeatUISample/App.xaml.cs
+++ b/samples/ServiceProvidedUpbeatUISample/App.xaml.cs
@@ -25,16 +25,16 @@ public partial class App : Application
 
     private async void HandleApplicationStartup(object sender, StartupEventArgs e)
     {
-        {
-            // Use a ServiceProvider (built from a ServiceCollection) to set up dependencies that the ServiceProvidedUpbeatStack will inject into ViewModels. Scoped services are supported, and each ViewModel within the stack is a separate scope.
-            using var serviceProvider = new ServiceCollection()
-                .AddTransient(sp => RandomNumberGenerator.Create())
-                .AddSingleton<SharedTimer>()
-                .AddScoped<SharedList>()
-                .BuildServiceProvider();
+        // Use a ServiceProvider (built from a ServiceCollection) to set up dependencies that the ServiceProvidedUpbeatStack will inject into ViewModels. Scoped services are supported, and each ViewModel within the stack is a separate scope.
+        using var serviceProvider = new ServiceCollection()
+            .AddTransient(sp => RandomNumberGenerator.Create())
+            .AddSingleton<SharedTimer>()
+            .AddScoped<SharedList>()
+            .BuildServiceProvider();
 
-            // The ServiceProvidedUpbeatStack is the central data structure for an UpbeatUI app. One must be created for the life of the application and should be disposed at the end. Unlike the basic UpbeatStack, the ServiceProvidedUpbeatStack requires an IServiceProvider to resolve dependencies for ViewModels.
-            using var upbeatStack = new ServiceProvidedUpbeatStack(serviceProvider);
+        // The ServiceProvidedUpbeatStack is the central data structure for an UpbeatUI app. One must be created for the life of the application and should be disposed at the end. Unlike the basic UpbeatStack, the ServiceProvidedUpbeatStack requires an IServiceProvider to resolve dependencies for ViewModels.
+        using (var upbeatStack = new ServiceProvidedUpbeatStack(serviceProvider))
+        {
 
             // Instead of manually mapping Parameters types to ViewModels and controls, the ServiceProvidedUpbeatStack can automatically map types based on naming convention. Use this method to enable the default naming convention, but other methods enable you to use your own naming conventions.
             upbeatStack.SetDefaultViewModelLocators();
@@ -112,7 +112,18 @@ public partial class App : Application
         }
         if (_exception is not null)
         {
-            _ = MessageBox.Show($"Exception: {_exception.GetType().FullName} {_exception.Message}");
+            if (MessageBox.Show(
+                $"Error message: {_exception.Message}. See stack trace?",
+                "Fatal Error",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Error) == MessageBoxResult.Yes)
+            {
+                _ = MessageBox.Show(
+                    _exception.StackTrace,
+                    "Fatal Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.None);
+            }
         }
     }
 

--- a/samples/ServiceProvidedUpbeatUISample/App.xaml.cs
+++ b/samples/ServiceProvidedUpbeatUISample/App.xaml.cs
@@ -13,6 +13,7 @@ using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Security.Cryptography;
 using System.Windows.Media.Effects;
+using System.Windows.Threading;
 
 namespace ServiceProvidedUpbeatUISample;
 
@@ -20,75 +21,105 @@ public partial class App : Application
 {
     // This app would like to provide a way for the user to cancel exiting. To do so, we create a shared task that can be triggered and reset.
     private TaskCompletionSource _closeRequestedTask = new();
+    private Exception _exception;
 
     private async void HandleApplicationStartup(object sender, StartupEventArgs e)
     {
-        // Use a ServiceProvider (built from a ServiceCollection) to set up dependencies that the ServiceProvidedUpbeatStack will inject into ViewModels. Scoped services are supported, and each ViewModel within the stack is a separate scope.
-        using var serviceProvider = new ServiceCollection()
-            .AddTransient(sp => RandomNumberGenerator.Create())
-            .AddSingleton<SharedTimer>()
-            .AddScoped<SharedList>()
-            .BuildServiceProvider();
-
-        // The ServiceProvidedUpbeatStack is the central data structure for an UpbeatUI app. One must be created for the life of the application and should be disposed at the end. Unlike the basic UpbeatStack, the ServiceProvidedUpbeatStack requires an IServiceProvider to resolve dependencies for ViewModels.
-        using var upbeatStack = new ServiceProvidedUpbeatStack(serviceProvider);
-
-        // Instead of manually mapping Parameters types to ViewModels and controls, the ServiceProvidedUpbeatStack can automatically map types based on naming convention. Use this method to enable the default naming convention, but other methods enable you to use your own naming conventions.
-        upbeatStack.SetDefaultViewModelLocators();
-
-        // The MenuViewModel's constructor requires an Action that it can use to start closing the application. We will provide the shared _closeRequestedTask's TrySetResult() method to indicate the user has requested to close the application. Because a simple Action should not be registered with the ServiceProvider (at least without creating an additional service class), we will instead manually map the MenuViewModel's constructor to its Parameters type.
-        upbeatStack.MapViewModel<MenuViewModel.Parameters, MenuViewModel>(
-            (upbeatService, parameters, serviceProvider) => new MenuViewModel(
-                    upbeatService,
-                    () => _closeRequestedTask.TrySetResult(),
-                    serviceProvider.GetRequiredService<SharedTimer>()));
-
-        // The included UpdateMainWindow class already provides the necessary controls to display Views for ViewModels when an IUpbeatStack is set as the DataContext.
-        var mainWindow = new UpbeatMainWindow()
         {
-            // You must set the DataContext to the ServiceProvidedUpbeatStack.
-            DataContext = upbeatStack,
-            Title = "UpbeatUI Sample Application",
-            MinHeight = 275,
-            MinWidth = 275,
-            Height = 400,
-            Width = 400,
-            WindowStartupLocation = WindowStartupLocation.CenterScreen,
-            ModalBackground = new SolidColorBrush(Brushes.LightGray.Color) { Opacity = 0.5 }, // The brush to display underneath the top View.
-            ModalBlurEffect = new BlurEffect() { Radius = 10.0, KernelType = KernelType.Gaussian }, // The blur effect to apply to Views that are not on top. This is optional, as blur effects can significantly impact performance.
-        };
+            // Use a ServiceProvider (built from a ServiceCollection) to set up dependencies that the ServiceProvidedUpbeatStack will inject into ViewModels. Scoped services are supported, and each ViewModel within the stack is a separate scope.
+            using var serviceProvider = new ServiceCollection()
+                .AddTransient(sp => RandomNumberGenerator.Create())
+                .AddSingleton<SharedTimer>()
+                .AddScoped<SharedList>()
+                .BuildServiceProvider();
 
-        // Override the default Window Closing event to request a close instead of immediately closing itself.
-        void HandleMainWindowClosing(object sender, CancelEventArgs e)
-        {
-            e.Cancel = true;
-            _ = _closeRequestedTask.TrySetResult();
-        }
-        mainWindow.Closing += HandleMainWindowClosing;
-        // When the UpbeatStack has no more view models, the 'ViewModelsEmptied' event will be triggered, so we can count that as a request to close the application.
-        void HandleUpbeatStackEmpied(object sender, EventArgs e) => _closeRequestedTask.TrySetResult();
-        upbeatStack.ViewModelsEmptied += HandleUpbeatStackEmpied;
+            // The ServiceProvidedUpbeatStack is the central data structure for an UpbeatUI app. One must be created for the life of the application and should be disposed at the end. Unlike the basic UpbeatStack, the ServiceProvidedUpbeatStack requires an IServiceProvider to resolve dependencies for ViewModels.
+            using var upbeatStack = new ServiceProvidedUpbeatStack(serviceProvider);
 
-        // Add a base BottomViewModel to the UpbeatStack.
-        upbeatStack.OpenViewModel(new BottomViewModel.Parameters());
+            // Instead of manually mapping Parameters types to ViewModels and controls, the ServiceProvidedUpbeatStack can automatically map types based on naming convention. Use this method to enable the default naming convention, but other methods enable you to use your own naming conventions.
+            upbeatStack.SetDefaultViewModelLocators();
 
-        // We are now ready to show the main window.
-        mainWindow.Show();
+            // The MenuViewModel's constructor requires an Action that it can use to start closing the application. We will provide the shared _closeRequestedTask's TrySetResult() method to indicate the user has requested to close the application. Because a simple Action should not be registered with the ServiceProvider (at least without creating an additional service class), we will instead manually map the MenuViewModel's constructor to its Parameters type.
+            upbeatStack.MapViewModel<MenuViewModel.Parameters, MenuViewModel>(
+                (upbeatService, parameters, serviceProvider) => new MenuViewModel(
+                        upbeatService,
+                        () => _closeRequestedTask.TrySetResult(),
+                        serviceProvider.GetRequiredService<SharedTimer>()));
 
-        // We set up an infinite loop to await the shared _closeRequestedTask, then attempt to close all ViewModels. If successful, we can exit the application. If not successful, possibly because the user cancelled closing, then reset the shared task and await again.
-        while (true)
-        {
-            await _closeRequestedTask.Task.ConfigureAwait(true);
-            if (await upbeatStack.TryCloseAllViewModelsAsync().ConfigureAwait(true))
+            // The included UpdateMainWindow class already provides the necessary controls to display Views for ViewModels when an IUpbeatStack is set as the DataContext.
+            var mainWindow = new UpbeatMainWindow()
             {
-                break;
-            }
-            _closeRequestedTask = new TaskCompletionSource();
-        }
+                // You must set the DataContext to the ServiceProvidedUpbeatStack.
+                DataContext = upbeatStack,
+                Title = "UpbeatUI Sample Application",
+                MinHeight = 275,
+                MinWidth = 275,
+                Height = 400,
+                Width = 400,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen,
+                ModalBackground = new SolidColorBrush(Brushes.LightGray.Color) { Opacity = 0.5 }, // The brush to display underneath the top View.
+                ModalBlurEffect = new BlurEffect() { Radius = 10.0, KernelType = KernelType.Gaussian }, // The blur effect to apply to Views that are not on top. This is optional, as blur effects can significantly impact performance.
+            };
 
-        upbeatStack.ViewModelsEmptied -= HandleUpbeatStackEmpied;
-        mainWindow.Closing -= HandleMainWindowClosing;
-        mainWindow.Close();
+            // Override the default Window Closing event to request a close instead of immediately closing itself.
+            void HandleMainWindowClosing(object sender, CancelEventArgs e)
+            {
+                e.Cancel = true;
+                _ = _closeRequestedTask.TrySetResult();
+            }
+            mainWindow.Closing += HandleMainWindowClosing;
+            // When the UpbeatStack has no more view models, the 'ViewModelsEmptied' event will be triggered, so we can count that as a request to close the application.
+            void HandleUpbeatStackEmpied(object sender, EventArgs e) => _closeRequestedTask.TrySetResult();
+            upbeatStack.ViewModelsEmptied += HandleUpbeatStackEmpied;
+            // Add a mechanism to catch unhandled exceptions.
+            void HandleApplicationException(object sender, DispatcherUnhandledExceptionEventArgs e)
+            {
+                e.Handled = true;
+                _exception = e.Exception;
+                _ = _closeRequestedTask.TrySetException(e.Exception);
+            }
+            Current.DispatcherUnhandledException += HandleApplicationException;
+
+            try
+            {
+                // Add a base BottomViewModel to the UpbeatStack.
+                upbeatStack.OpenViewModel(new BottomViewModel.Parameters());
+
+                // We are now ready to show the main window.
+                mainWindow.Show();
+
+                // We set up an infinite loop to await the shared _closeRequestedTask, then attempt to close all ViewModels. If successful, we can exit the application. If not successful, possibly because the user cancelled closing, then reset the shared task and await again.
+                while (true)
+                {
+                    await _closeRequestedTask.Task.ConfigureAwait(true);
+                    if (await upbeatStack.TryCloseAllViewModelsAsync().ConfigureAwait(true))
+                    {
+                        break;
+                    }
+                    _closeRequestedTask = new TaskCompletionSource();
+                }
+            }
+            catch (Exception ex)
+            {
+                _exception ??= ex;
+            }
+            finally
+            {
+                upbeatStack.ViewModelsEmptied -= HandleUpbeatStackEmpied;
+                mainWindow.Closing -= HandleMainWindowClosing;
+                mainWindow.Close();
+            }
+        }
+        if (_exception is not null)
+        {
+            _ = MessageBox.Show($"Exception: {_exception.GetType().FullName} {_exception.Message}");
+        }
+    }
+
+    private void HandleApplicationException(object sender, DispatcherUnhandledExceptionEventArgs e)
+    {
+        e.Handled = true;
+        _ = _closeRequestedTask.TrySetException(e.Exception);
     }
 }
 

--- a/source/UpbeatUI.Extensions.Hosting/HostedUpbeatBuilder.cs
+++ b/source/UpbeatUI.Extensions.Hosting/HostedUpbeatBuilder.cs
@@ -16,7 +16,7 @@ namespace UpbeatUI.Extensions.Hosting
         internal Func<object> BaseViewModelParametersCreator { get; private set; }
         internal Collection<Action<ServiceProvidedUpbeatStack>> MappingRegisterers { get; } = new Collection<Action<ServiceProvidedUpbeatStack>>();
         internal Func<Window> WindowCreator { get; private set; } = () => new UpbeatMainWindow();
-        internal Action<Exception> FatalErrorHandler { get; private set; }
+        internal Action<IServiceProvider, Exception> FatalErrorHandler { get; private set; }
 
         public IHostedUpbeatBuilder ConfigureWindow(Func<Window> windowCreator)
         {
@@ -60,9 +60,15 @@ namespace UpbeatUI.Extensions.Hosting
             return this;
         }
 
-        public IHostedUpbeatBuilder SetFatalErrorHandler(Action<Exception> fatalErrorHandler)
+        public IHostedUpbeatBuilder SetFatalErrorHandler(Action<IServiceProvider, Exception> fatalErrorHandler)
         {
             FatalErrorHandler = fatalErrorHandler;
+            return this;
+        }
+
+        public IHostedUpbeatBuilder SetFatalErrorHandler(Action<Exception> fatalErrorHandler)
+        {
+            FatalErrorHandler = (_, e) => fatalErrorHandler(e);
             return this;
         }
 

--- a/source/UpbeatUI.Extensions.Hosting/HostedUpbeatBuilder.cs
+++ b/source/UpbeatUI.Extensions.Hosting/HostedUpbeatBuilder.cs
@@ -16,6 +16,7 @@ namespace UpbeatUI.Extensions.Hosting
         internal Func<object> BaseViewModelParametersCreator { get; private set; }
         internal Collection<Action<ServiceProvidedUpbeatStack>> MappingRegisterers { get; } = new Collection<Action<ServiceProvidedUpbeatStack>>();
         internal Func<Window> WindowCreator { get; private set; } = () => new UpbeatMainWindow();
+        internal Action<Exception> FatalErrorHandler { get; private set; }
 
         public IHostedUpbeatBuilder ConfigureWindow(Func<Window> windowCreator)
         {
@@ -56,6 +57,12 @@ namespace UpbeatUI.Extensions.Hosting
         {
             MappingRegisterers.Add(
                 upbeatStack => upbeatStack.SetDefaultViewModelLocators(allowUnresolvedDependencies));
+            return this;
+        }
+
+        public IHostedUpbeatBuilder SetFatalErrorHandler(Action<Exception> fatalErrorHandler)
+        {
+            FatalErrorHandler = fatalErrorHandler;
             return this;
         }
 

--- a/source/UpbeatUI.Extensions.Hosting/HostedUpbeatBuilder.cs
+++ b/source/UpbeatUI.Extensions.Hosting/HostedUpbeatBuilder.cs
@@ -68,7 +68,14 @@ namespace UpbeatUI.Extensions.Hosting
 
         public IHostedUpbeatBuilder SetFatalErrorHandler(Action<Exception> fatalErrorHandler)
         {
-            FatalErrorHandler = (_, e) => fatalErrorHandler(e);
+            if (fatalErrorHandler == null)
+            {
+                fatalErrorHandler = null;
+            }
+            else
+            {
+                return SetFatalErrorHandler((_, e) => fatalErrorHandler(e));
+            }
             return this;
         }
 

--- a/source/UpbeatUI.Extensions.Hosting/HostedUpbeatService.cs
+++ b/source/UpbeatUI.Extensions.Hosting/HostedUpbeatService.cs
@@ -81,7 +81,14 @@ namespace UpbeatUI.Extensions.Hosting
                     }
                     catch (Exception e)
                     {
-                        _exception ??= e;
+                        if (_upbeatHostBuilder.FatalErrorHandler != null)
+                        {
+                            _exception ??= e;
+                        }
+                        else
+                        {
+                            throw;
+                        }
                     }
                     finally
                     {
@@ -92,7 +99,7 @@ namespace UpbeatUI.Extensions.Hosting
                         _upbeatApplicationService.CloseRequested -= HandleUpbeatApplicationServiceCloseRequested;
                     }
                 }
-                if (_exception != null && _upbeatHostBuilder.FatalErrorHandler != null)
+                if (_exception != null)
                 {
                     _upbeatHostBuilder.FatalErrorHandler(_serviceProvider, _exception);
                 }

--- a/source/UpbeatUI.Extensions.Hosting/IHostedUpbeatBuilder.cs
+++ b/source/UpbeatUI.Extensions.Hosting/IHostedUpbeatBuilder.cs
@@ -68,6 +68,15 @@ namespace UpbeatUI.Extensions.Hosting
         IHostedUpbeatBuilder SetDefaultViewModelLocators(bool allowUnresolvedDependencies = false);
 
         /// <summary>
+        /// Sets a delegate that will be executed prior to application shutdown if there is an unhandled <see cref="Exception"/>. This can be used to notify the user, log the error, etc...
+        /// <para>Note: This delegate will execute after all ViewModels have been removed and disposed, and also after the <see cref="IUpbeatStack"/> has been disposed. Any other services instantiated by the <see cref="IServiceProvider"/> will likely also have been disposed as well, though this cannot be guaranteed.</para>
+        /// </summary>
+        /// <param name="fatalErrorHandler">A delegate with the offending <see cref="Exception"/> as its parameter.</param>
+        /// <returns></returns>
+        public IHostedUpbeatBuilder SetFatalErrorHandler(Action<Exception> fatalErrorHandler);
+
+
+        /// <summary>
         /// Sets delegates the <see cref="UpbeatStack"/> can use to automatically map a <see cref="string"/> representation of a Parameters <see cref="Type"/> to <see cref="string"/> represetantions of a ViewModel <see cref="Type"/> and a View <see cref="Type"/>.
         /// <para>Note: Each <see cref="string"/> representation is a <see cref="Type.AssemblyQualifiedName"/></para>
         /// </summary>

--- a/source/UpbeatUI.Extensions.Hosting/IHostedUpbeatBuilder.cs
+++ b/source/UpbeatUI.Extensions.Hosting/IHostedUpbeatBuilder.cs
@@ -68,10 +68,18 @@ namespace UpbeatUI.Extensions.Hosting
         IHostedUpbeatBuilder SetDefaultViewModelLocators(bool allowUnresolvedDependencies = false);
 
         /// <summary>
-        /// Sets a delegate that will be executed prior to application shutdown if there is an unhandled <see cref="Exception"/>. This can be used to notify the user, log the error, etc...
-        /// <para>Note: This delegate will execute after all ViewModels have been removed and disposed, and also after the <see cref="IUpbeatStack"/> has been disposed. Any other services instantiated by the <see cref="IServiceProvider"/> will likely also have been disposed as well, though this cannot be guaranteed.</para>
+        /// Sets a delegate that will be executed prior to application shutdown if there is an unhandled <see cref="Exception"/>. This can be used to notify the user, log the error, etc... The application's <see cref="IServiceProvider"/> is also available to access registered services, though the health of any singleton services cannot be guaranteed and will depend on their use within the application and the nature of the offending <see cref="Exception"/>.
+        /// <para>Note: This delegate will execute after all ViewModels have been removed and disposed, and also after the <see cref="IUpbeatStack"/> has been disposed.</para>
         /// </summary>
-        /// <param name="fatalErrorHandler">A delegate with the offending <see cref="Exception"/> as its parameter.</param>
+        /// <param name="fatalErrorHandler">A delegate with the application's <see cref="IServiceProvider"/> and the offending <see cref="Exception"/> as its parameters.</param>
+        /// <returns></returns>
+        public IHostedUpbeatBuilder SetFatalErrorHandler(Action<IServiceProvider, Exception> fatalErrorHandler);
+
+        /// <summary>
+        /// Sets a delegate that will be executed prior to application shutdown if there is an unhandled <see cref="Exception"/>. This can be used to notify the user, log the error, etc...
+        /// <para>Note: This delegate will execute after all ViewModels have been removed and disposed, and also after the <see cref="IUpbeatStack"/> has been disposed.</para>
+        /// </summary>
+        /// <param name="fatalErrorHandler">A delegate with the the offending <see cref="Exception"/> as its parameter.</param>
         /// <returns></returns>
         public IHostedUpbeatBuilder SetFatalErrorHandler(Action<Exception> fatalErrorHandler);
 

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -22,8 +22,8 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>4.2.0</Version>
-        <PackageValidationBaselineVersion>4.1.0</PackageValidationBaselineVersion>
+        <Version>5.0.0-rc1</Version>
+        <!-- <PackageValidationBaselineVersion>4.2.0</PackageValidationBaselineVersion> -->
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -22,7 +22,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>5.0.0-rc1</Version>
+        <Version>5.0.0-rc2</Version>
         <!-- <PackageValidationBaselineVersion>4.2.0</PackageValidationBaselineVersion> -->
     </PropertyGroup>
 

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -22,7 +22,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>5.0.0-rc2</Version>
+        <Version>5.0.0-rc3</Version>
         <!-- <PackageValidationBaselineVersion>4.2.0</PackageValidationBaselineVersion> -->
     </PropertyGroup>
 


### PR DESCRIPTION
1. Adds an optional `SetFatalErrorHandler` extension method when configuring the hosted Upbeat service. If an unhandled exception causes the application to crash, the error handler will be called just before exit.
2. Adds error handling to the samples using the new `SetFatalErrorHandler` for the for the Hosted sample and  Manually for the two.