### PR TITLE
Adds optional overlay feature to the UpbeatMainWindow

### DIFF
--- a/samples/HostedUpbeatUISample/App.xaml
+++ b/samples/HostedUpbeatUISample/App.xaml
@@ -21,6 +21,7 @@
                 <ResourceDictionary Source="View\RandomDataTemplate.xaml " />
                 <ResourceDictionary Source="View\SharedListTemplate.xaml " />
                 <ResourceDictionary Source="View\TextEntryPopupTemplate.xaml" />
+                <ResourceDictionary Source="View\OverlayTemplate.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/samples/HostedUpbeatUISample/App.xaml.cs
+++ b/samples/HostedUpbeatUISample/App.xaml.cs
@@ -22,6 +22,7 @@ public partial class App : Application
             .ConfigureServices((hostContext, serviceCollection) => serviceCollection // Services can be configured, just as in other Hosted projects like ASP.NET Core applications. The IUpbeatStack will inject them into ViewModels when appropriate. Scoped services are supported, and each ViewModel within the stack is a separate scope.
                 .AddTransient(sp => RandomNumberGenerator.Create())
                 .AddSingleton<SharedTimer>()
+                .AddSingleton<OverlayService>()
                 .AddScoped<SharedList>())
             .ConfigureUpbeatHost( // Use this extension method to add UpbeatUI to the IHostBuilder
                 () => new BottomViewModel.Parameters(), // Provide a delegate to create the bottom ViewModel. This is required so that the IUpbeatStack has something to show.
@@ -52,7 +53,8 @@ public partial class App : Application
                                 MessageBoxButton.OK,
                                 MessageBoxImage.None);
                         }
-                    }))
+                    })
+                    .SetOverlayViewModel<OverlayViewModel>())
             .Build()
             .RunAsync().ConfigureAwait(true);
 }

--- a/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
+++ b/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
@@ -23,7 +23,7 @@
     <ItemGroup>
         <PackageReference
             Include="UpbeatUI.Extensions.Hosting"
-            Version="5.0.0-rc4" />
+            Version="5.0.0-rc5" />
         <!-- Switch from the PackageReference to the ProjectReference to test local UpbeatUI changes in the samples. -->
         <!-- <ProjectReference Include="..\..\source\UpbeatUI.Extensions.Hosting\UpbeatUI.Extensions.Hosting.csproj" /> -->
     </ItemGroup>

--- a/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
+++ b/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
@@ -23,7 +23,7 @@
     <ItemGroup>
         <PackageReference
             Include="UpbeatUI.Extensions.Hosting"
-            Version="5.0.0-rc2" />
+            Version="5.0.0-rc4" />
         <!-- Switch from the PackageReference to the ProjectReference to test local UpbeatUI changes in the samples. -->
         <!-- <ProjectReference Include="..\..\source\UpbeatUI.Extensions.Hosting\UpbeatUI.Extensions.Hosting.csproj" /> -->
     </ItemGroup>

--- a/samples/HostedUpbeatUISample/OverlayService.cs
+++ b/samples/HostedUpbeatUISample/OverlayService.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace HostedUpbeatUISample;
 
-// This is a simple list wrapper to demonstrate a scoped service shared between multiple ViewModels.
+// This is a shared service that ViewModels can use to control visibility of the application overlay.
 public class OverlayService
 {
     private bool _overlayVisible;

--- a/samples/HostedUpbeatUISample/OverlayService.cs
+++ b/samples/HostedUpbeatUISample/OverlayService.cs
@@ -1,0 +1,28 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System;
+
+namespace HostedUpbeatUISample;
+
+// This is a simple list wrapper to demonstrate a scoped service shared between multiple ViewModels.
+public class OverlayService
+{
+    private bool _overlayVisible;
+
+    public event EventHandler OverlayToggled;
+
+    public bool OverlayVisible
+    {
+        get => _overlayVisible;
+        set
+        {
+            if (value != _overlayVisible)
+            {
+                _overlayVisible = value;
+                OverlayToggled?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/samples/HostedUpbeatUISample/View/MenuTemplate.xaml
+++ b/samples/HostedUpbeatUISample/View/MenuTemplate.xaml
@@ -47,6 +47,9 @@
                     <ToggleButton
                         IsChecked="{Binding Fullscreen, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type uv:UpbeatMainWindow}}}"
                         Margin="5">Fullscreen</ToggleButton>
+                    <ToggleButton
+                        IsChecked="{Binding ShowOverlay}"
+                        Margin="5">Show Overlay</ToggleButton>
                     <TextBlock
                         TextAlignment="Center"
                         Margin="5"

--- a/samples/HostedUpbeatUISample/View/OverlayTemplate.xaml
+++ b/samples/HostedUpbeatUISample/View/OverlayTemplate.xaml
@@ -1,0 +1,46 @@
+<!-- This file is part of the UpbeatUI project, which is released under MIT License.
+     See LICENSE.md or visit:
+     https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+     -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:uv="clr-namespace:UpbeatUI.View;assembly=UpbeatUI"
+    xmlns:svm="clr-namespace:HostedUpbeatUISample.ViewModel">
+    <!-- Note that "DataType" for this DataTemplate refers to a specific ViewModel class. When an instance of that
+         ViewModel class is added to the stack, this DataTemplate will be used to display content. The VieWModel
+         instance will be the "DataContext". -->
+    <DataTemplate DataType="{x:Type svm:OverlayViewModel}">
+        <Grid
+            Background="LightGray"
+            Opacity="0.5">
+            <Grid.Style>
+                <Style TargetType="Grid">
+                    <Setter
+                        Property="Visibility"
+                        Value="Collapsed" />
+                    <Style.Triggers>
+                        <DataTrigger
+                            Binding="{Binding Visible}"
+                            Value="True">
+                            <Setter
+                                Property="Visibility"
+                                Value="Visible" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Style>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Viewbox>
+                <TextBlock Text="{Binding Message}" />
+            </Viewbox>
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary>

--- a/samples/HostedUpbeatUISample/ViewModel/MenuViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/MenuViewModel.cs
@@ -18,17 +18,19 @@ public sealed partial class MenuViewModel : ObservableObject, IDisposable
     private readonly IUpbeatService _upbeatService;
     private readonly IUpbeatApplicationService _hostedUpbeatService;
     private readonly SharedTimer _sharedTimer;
+    private readonly OverlayService _overlayService;
     private readonly Stopwatch _stopwatch = new();
 
     public MenuViewModel(
         IUpbeatService upbeatService, // This will be a unique IUpbeatService created and injected by the IUpbeatStack specifically for this ViewModel.
         IUpbeatApplicationService hostedUpbeatService, // IUpbeatApplicationService provides a method allowing ViewModels to start application shutdown.
-        SharedTimer sharedTimer) // This is a shared singleton service.
+        SharedTimer sharedTimer, // This is a shared singleton service.
+        OverlayService overlayService) // This is a shared singleton service.
     {
         _upbeatService = upbeatService ?? throw new ArgumentNullException(nameof(upbeatService));
         _hostedUpbeatService = hostedUpbeatService ?? throw new ArgumentNullException(nameof(hostedUpbeatService));
         _sharedTimer = sharedTimer ?? throw new ArgumentNullException(nameof(sharedTimer));
-
+        _overlayService = overlayService ?? throw new ArgumentNullException(nameof(overlayService));
         _stopwatch.Start();
         _upbeatService.RegisterUpdateCallback(() => OnPropertyChanged(nameof(Visibility))); // Registered "UpdateCallbacks" will be called each time the UI thread renders a new frame.
 
@@ -37,6 +39,15 @@ public sealed partial class MenuViewModel : ObservableObject, IDisposable
 
     public string SecondsElapsed => $"{_sharedTimer.ElapsedSeconds} Seconds";
     public double Visibility => Math.Abs(1000.0 - _stopwatch.ElapsedMilliseconds % 2000) / 1000.0; // Will be calculated on each "OnPropertyChanged(nameof(Visibility))" and used in the View to control visibility of an ellipse. Cycles between full and no visibility every two seconds.
+    public bool ShowOverlay
+    {
+        get => _overlayService.OverlayVisible;
+        set => SetProperty(
+            _overlayService.OverlayVisible,
+            value,
+            _overlayService,
+            (os, v) => os.OverlayVisible = v);
+    }
 
     // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. As an attribute, it can be used to automatically wrap methods within ICommand properties. It supports both async and non-async methods/lambdas.
     [RelayCommand]

--- a/samples/HostedUpbeatUISample/ViewModel/OverlayViewModel.cs
+++ b/samples/HostedUpbeatUISample/ViewModel/OverlayViewModel.cs
@@ -1,0 +1,30 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace HostedUpbeatUISample.ViewModel;
+
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public sealed partial class OverlayViewModel : ObservableObject, IDisposable
+{
+    private readonly OverlayService _overlayService;
+    [ObservableProperty]
+    private string _message = "Overlay";
+    [ObservableProperty]
+    private bool _visible;
+
+    public OverlayViewModel(OverlayService overlayService)
+    {
+        _overlayService = overlayService ?? throw new ArgumentNullException(nameof(overlayService));
+        _overlayService.OverlayToggled += HandleOverlayToggled;
+    }
+
+    public void Dispose() =>
+        _overlayService.OverlayToggled -= HandleOverlayToggled;
+
+    private void HandleOverlayToggled(object sender, EventArgs e) =>
+        Visible = _overlayService.OverlayVisible;
+}

--- a/samples/ManualUpbeatUISample/App.xaml
+++ b/samples/ManualUpbeatUISample/App.xaml
@@ -21,6 +21,7 @@
                 <ResourceDictionary Source="View\RandomDataTemplate.xaml " />
                 <ResourceDictionary Source="View\SharedListTemplate.xaml " />
                 <ResourceDictionary Source="View\TextEntryPopupTemplate.xaml" />
+                <ResourceDictionary Source="View\OverlayTemplate.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/samples/ManualUpbeatUISample/App.xaml.cs
+++ b/samples/ManualUpbeatUISample/App.xaml.cs
@@ -25,6 +25,7 @@ public partial class App : Application
     private async void HandleApplicationStartup(object sender, StartupEventArgs e)
     {
         using var sharedTimer = new SharedTimer();
+        var overlayService = new OverlayService();
 
         // The UpbeatStack is the central data structure for an UpbeatUI app. One must be created for the life of the application and should be disposed at the end.
         using (var upbeatStack = new UpbeatStack())
@@ -38,7 +39,7 @@ public partial class App : Application
 
             // The MenuViewModel's constructor requires an Action that it can use to start closing the application. We will provide the shared _closeRequestedTask's TrySetResult() method to indicate the user has requested to close the application.
             upbeatStack.MapViewModel<MenuViewModel.Parameters, MenuViewModel>(
-                (upbeatService, parameters) => new MenuViewModel(upbeatService, () => _closeRequestedTask.TrySetResult(), sharedTimer));
+                (upbeatService, parameters) => new MenuViewModel(upbeatService, () => _closeRequestedTask.TrySetResult(), sharedTimer, overlayService));
             upbeatStack.MapViewModel<PopupViewModel.Parameters, PopupViewModel>(
                 (upbeatService, parameters) => new PopupViewModel(parameters, sharedTimer));
             upbeatStack.MapViewModel<RandomDataViewModel.Parameters, RandomDataViewModel>(
@@ -54,6 +55,7 @@ public partial class App : Application
             upbeatStack.MapViewModel<TextEntryPopupViewModel.Parameters, TextEntryPopupViewModel>(
                 (upbeatService, parameters) => new TextEntryPopupViewModel(upbeatService, parameters, sharedTimer));
 
+            using var overlayViewModel = new OverlayViewModel(overlayService);
             // The included UpdateMainWindow class already provides the necessary controls to display Views for ViewModels when an IUpbeatStack is set as the DataContext.
             var mainWindow = new UpbeatMainWindow()
             {
@@ -67,6 +69,7 @@ public partial class App : Application
                 WindowStartupLocation = WindowStartupLocation.CenterScreen,
                 ModalBackground = new SolidColorBrush(Brushes.LightGray.Color) { Opacity = 0.5 }, // The brush to display underneath the top View.
                 ModalBlurEffect = new BlurEffect() { Radius = 10.0, KernelType = KernelType.Gaussian }, // The blur effect to apply to Views that are not on top. This is optional, as blur effects can significantly impact performance.
+                OverlayDataContext = overlayViewModel,
             };
 
             // Override the default Window Closing event to request a close instead of immediately closing itself.

--- a/samples/ManualUpbeatUISample/ManualUpbeatUISample.csproj
+++ b/samples/ManualUpbeatUISample/ManualUpbeatUISample.csproj
@@ -20,7 +20,7 @@
     <ItemGroup>
         <PackageReference
             Include="UpbeatUI"
-            Version="5.2.0" />
+            Version="5.3.0-rc1" />
         <!-- Switch from the PackageReference to the ProjectReference to test local UpbeatUI changes in the samples. -->
         <!-- <ProjectReference Include="..\..\source\UpbeatUI\UpbeatUI.csproj" /> -->
     </ItemGroup>

--- a/samples/ManualUpbeatUISample/OverlayService.cs
+++ b/samples/ManualUpbeatUISample/OverlayService.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace ManualUpbeatUISample;
 
-// This is a simple list wrapper to demonstrate a scoped service shared between multiple ViewModels.
+// This is a shared service that ViewModels can use to control visibility of the application overlay.
 public class OverlayService
 {
     private bool _overlayVisible;

--- a/samples/ManualUpbeatUISample/OverlayService.cs
+++ b/samples/ManualUpbeatUISample/OverlayService.cs
@@ -1,0 +1,28 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System;
+
+namespace ManualUpbeatUISample;
+
+// This is a simple list wrapper to demonstrate a scoped service shared between multiple ViewModels.
+public class OverlayService
+{
+    private bool _overlayVisible;
+
+    public event EventHandler OverlayToggled;
+
+    public bool OverlayVisible
+    {
+        get => _overlayVisible;
+        set
+        {
+            if (value != _overlayVisible)
+            {
+                _overlayVisible = value;
+                OverlayToggled?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/samples/ManualUpbeatUISample/View/MenuTemplate.xaml
+++ b/samples/ManualUpbeatUISample/View/MenuTemplate.xaml
@@ -47,6 +47,9 @@
                     <ToggleButton
                         IsChecked="{Binding Fullscreen, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type uv:UpbeatMainWindow}}}"
                         Margin="5">Fullscreen</ToggleButton>
+                    <ToggleButton
+                        IsChecked="{Binding ShowOverlay}"
+                        Margin="5">Show Overlay</ToggleButton>
                     <TextBlock
                         TextAlignment="Center"
                         Margin="5"

--- a/samples/ManualUpbeatUISample/View/OverlayTemplate.xaml
+++ b/samples/ManualUpbeatUISample/View/OverlayTemplate.xaml
@@ -1,0 +1,46 @@
+<!-- This file is part of the UpbeatUI project, which is released under MIT License.
+     See LICENSE.md or visit:
+     https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+     -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:uv="clr-namespace:UpbeatUI.View;assembly=UpbeatUI"
+    xmlns:svm="clr-namespace:ManualUpbeatUISample.ViewModel">
+    <!-- Note that "DataType" for this DataTemplate refers to a specific ViewModel class. When an instance of that
+         ViewModel class is added to the stack, this DataTemplate will be used to display content. The VieWModel
+         instance will be the "DataContext". -->
+    <DataTemplate DataType="{x:Type svm:OverlayViewModel}">
+        <Grid
+            Background="LightGray"
+            Opacity="0.5">
+            <Grid.Style>
+                <Style TargetType="Grid">
+                    <Setter
+                        Property="Visibility"
+                        Value="Collapsed" />
+                    <Style.Triggers>
+                        <DataTrigger
+                            Binding="{Binding Visible}"
+                            Value="True">
+                            <Setter
+                                Property="Visibility"
+                                Value="Visible" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Style>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Viewbox>
+                <TextBlock Text="{Binding Message}" />
+            </Viewbox>
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary>

--- a/samples/ManualUpbeatUISample/ViewModel/MenuViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/MenuViewModel.cs
@@ -17,17 +17,19 @@ public sealed partial class MenuViewModel : ObservableObject, IDisposable
     private readonly IUpbeatService _upbeatService;
     private readonly Action _closeApplicationCallback;
     private readonly SharedTimer _sharedTimer;
+    private readonly OverlayService _overlayService;
     private readonly Stopwatch _stopwatch = new();
 
     public MenuViewModel(
         IUpbeatService upbeatService, // This will be a unique IUpbeatService created and injected by the IUpbeatStack specifically for this ViewModel.
         Action closeApplicationCallback, // This ViewModel requires an Action delegate to be provided, so it can start closing the application.
-        SharedTimer sharedTimer) // This is a shared singleton service.
+        SharedTimer sharedTimer, // This is a shared singleton service.
+        OverlayService overlayService) // This is a shared singleton service.
     {
         _upbeatService = upbeatService ?? throw new ArgumentNullException(nameof(upbeatService));
         _closeApplicationCallback = closeApplicationCallback ?? throw new ArgumentNullException(nameof(closeApplicationCallback));
         _sharedTimer = sharedTimer ?? throw new ArgumentNullException(nameof(sharedTimer));
-
+        _overlayService = overlayService ?? throw new ArgumentNullException(nameof(overlayService));
         _stopwatch.Start();
         _upbeatService.RegisterUpdateCallback(() => OnPropertyChanged(nameof(Visibility))); // Registered "UpdateCallbacks" will be called each time the UI thread renders a new frame.
 
@@ -36,6 +38,16 @@ public sealed partial class MenuViewModel : ObservableObject, IDisposable
 
     public string SecondsElapsed => $"{_sharedTimer.ElapsedSeconds} Seconds";
     public double Visibility => Math.Abs(1000.0 - _stopwatch.ElapsedMilliseconds % 2000) / 1000.0; // Will be calculated on each "OnPropertyChanged(nameof(Visibility))" and used in the View to control visibility of an ellipse. Cycles between full and no visibility every two seconds.
+    public bool ShowOverlay
+    {
+        get => _overlayService.OverlayVisible;
+        set => SetProperty(
+            _overlayService.OverlayVisible,
+            value,
+            _overlayService,
+            (os, v) => os.OverlayVisible = v);
+    }
+
 
     // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. As an attribute, it can be used to automatically wrap methods within ICommand properties. It supports both async and non-async methods/lambdas.
     [RelayCommand]

--- a/samples/ManualUpbeatUISample/ViewModel/OverlayViewModel.cs
+++ b/samples/ManualUpbeatUISample/ViewModel/OverlayViewModel.cs
@@ -1,0 +1,30 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ManualUpbeatUISample.ViewModel;
+
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public sealed partial class OverlayViewModel : ObservableObject, IDisposable
+{
+    private readonly OverlayService _overlayService;
+    [ObservableProperty]
+    private string _message = "Overlay";
+    [ObservableProperty]
+    private bool _visible;
+
+    public OverlayViewModel(OverlayService overlayService)
+    {
+        _overlayService = overlayService ?? throw new ArgumentNullException(nameof(overlayService));
+        _overlayService.OverlayToggled += HandleOverlayToggled;
+    }
+
+    public void Dispose() =>
+        _overlayService.OverlayToggled -= HandleOverlayToggled;
+
+    private void HandleOverlayToggled(object sender, EventArgs e) =>
+        Visible = _overlayService.OverlayVisible;
+}

--- a/samples/ServiceProvidedUpbeatUISample/App.xaml
+++ b/samples/ServiceProvidedUpbeatUISample/App.xaml
@@ -21,6 +21,7 @@
                 <ResourceDictionary Source="View\RandomDataTemplate.xaml " />
                 <ResourceDictionary Source="View\SharedListTemplate.xaml " />
                 <ResourceDictionary Source="View\TextEntryPopupTemplate.xaml" />
+                <ResourceDictionary Source="View\OverlayTemplate.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/samples/ServiceProvidedUpbeatUISample/App.xaml.cs
+++ b/samples/ServiceProvidedUpbeatUISample/App.xaml.cs
@@ -29,6 +29,7 @@ public partial class App : Application
         using var serviceProvider = new ServiceCollection()
             .AddTransient(sp => RandomNumberGenerator.Create())
             .AddSingleton<SharedTimer>()
+            .AddSingleton<OverlayService>()
             .AddScoped<SharedList>()
             .BuildServiceProvider();
 
@@ -44,8 +45,10 @@ public partial class App : Application
                 (upbeatService, parameters, serviceProvider) => new MenuViewModel(
                         upbeatService,
                         () => _closeRequestedTask.TrySetResult(),
-                        serviceProvider.GetRequiredService<SharedTimer>()));
+                        serviceProvider.GetRequiredService<SharedTimer>(),
+                        serviceProvider.GetRequiredService<OverlayService>()));
 
+            using var overlayViewModel = ActivatorUtilities.CreateInstance<OverlayViewModel>(serviceProvider);
             // The included UpdateMainWindow class already provides the necessary controls to display Views for ViewModels when an IUpbeatStack is set as the DataContext.
             var mainWindow = new UpbeatMainWindow()
             {
@@ -59,6 +62,7 @@ public partial class App : Application
                 WindowStartupLocation = WindowStartupLocation.CenterScreen,
                 ModalBackground = new SolidColorBrush(Brushes.LightGray.Color) { Opacity = 0.5 }, // The brush to display underneath the top View.
                 ModalBlurEffect = new BlurEffect() { Radius = 10.0, KernelType = KernelType.Gaussian }, // The blur effect to apply to Views that are not on top. This is optional, as blur effects can significantly impact performance.
+                OverlayDataContext = overlayViewModel,
             };
 
             // Override the default Window Closing event to request a close instead of immediately closing itself.

--- a/samples/ServiceProvidedUpbeatUISample/App.xaml.cs
+++ b/samples/ServiceProvidedUpbeatUISample/App.xaml.cs
@@ -48,7 +48,8 @@ public partial class App : Application
                         serviceProvider.GetRequiredService<SharedTimer>(),
                         serviceProvider.GetRequiredService<OverlayService>()));
 
-            using var overlayViewModel = ActivatorUtilities.CreateInstance<OverlayViewModel>(serviceProvider);
+            using var overlayScope = serviceProvider.CreateScope();
+            using var overlayViewModel = ActivatorUtilities.CreateInstance<OverlayViewModel>(overlayScope.ServiceProvider);
             // The included UpdateMainWindow class already provides the necessary controls to display Views for ViewModels when an IUpbeatStack is set as the DataContext.
             var mainWindow = new UpbeatMainWindow()
             {

--- a/samples/ServiceProvidedUpbeatUISample/OverlayService.cs
+++ b/samples/ServiceProvidedUpbeatUISample/OverlayService.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace ServiceProvidedUpbeatUISample;
 
-// This is a simple list wrapper to demonstrate a scoped service shared between multiple ViewModels.
+// This is a shared service that ViewModels can use to control visibility of the application overlay.
 public class OverlayService
 {
     private bool _overlayVisible;

--- a/samples/ServiceProvidedUpbeatUISample/OverlayService.cs
+++ b/samples/ServiceProvidedUpbeatUISample/OverlayService.cs
@@ -1,0 +1,28 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System;
+
+namespace ServiceProvidedUpbeatUISample;
+
+// This is a simple list wrapper to demonstrate a scoped service shared between multiple ViewModels.
+public class OverlayService
+{
+    private bool _overlayVisible;
+
+    public event EventHandler OverlayToggled;
+
+    public bool OverlayVisible
+    {
+        get => _overlayVisible;
+        set
+        {
+            if (value != _overlayVisible)
+            {
+                _overlayVisible = value;
+                OverlayToggled?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/samples/ServiceProvidedUpbeatUISample/ServiceProvidedUpbeatUISample.csproj
+++ b/samples/ServiceProvidedUpbeatUISample/ServiceProvidedUpbeatUISample.csproj
@@ -23,7 +23,7 @@
     <ItemGroup>
         <PackageReference
             Include="UpbeatUI.Extensions.DependencyInjection"
-            Version="2.2.0" />
+            Version="2.3.0-rc1" />
         <!-- Switch from the PackageReference to the ProjectReference to test local UpbeatUI changes in the samples. -->
         <!-- <ProjectReference Include="..\..\source\UpbeatUI.Extensions.DependencyInjection\UpbeatUI.Extensions.DependencyInjection.csproj" /> -->
     </ItemGroup>

--- a/samples/ServiceProvidedUpbeatUISample/View/MenuTemplate.xaml
+++ b/samples/ServiceProvidedUpbeatUISample/View/MenuTemplate.xaml
@@ -47,6 +47,9 @@
                     <ToggleButton
                         IsChecked="{Binding Fullscreen, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type uv:UpbeatMainWindow}}}"
                         Margin="5">Fullscreen</ToggleButton>
+                    <ToggleButton
+                        IsChecked="{Binding ShowOverlay}"
+                        Margin="5">Show Overlay</ToggleButton>
                     <TextBlock
                         TextAlignment="Center"
                         Margin="5"

--- a/samples/ServiceProvidedUpbeatUISample/View/OverlayTemplate.xaml
+++ b/samples/ServiceProvidedUpbeatUISample/View/OverlayTemplate.xaml
@@ -1,0 +1,46 @@
+<!-- This file is part of the UpbeatUI project, which is released under MIT License.
+     See LICENSE.md or visit:
+     https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+     -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:uv="clr-namespace:UpbeatUI.View;assembly=UpbeatUI"
+    xmlns:svm="clr-namespace:ServiceProvidedUpbeatUISample.ViewModel">
+    <!-- Note that "DataType" for this DataTemplate refers to a specific ViewModel class. When an instance of that
+         ViewModel class is added to the stack, this DataTemplate will be used to display content. The VieWModel
+         instance will be the "DataContext". -->
+    <DataTemplate DataType="{x:Type svm:OverlayViewModel}">
+        <Grid
+            Background="LightGray"
+            Opacity="0.5">
+            <Grid.Style>
+                <Style TargetType="Grid">
+                    <Setter
+                        Property="Visibility"
+                        Value="Collapsed" />
+                    <Style.Triggers>
+                        <DataTrigger
+                            Binding="{Binding Visible}"
+                            Value="True">
+                            <Setter
+                                Property="Visibility"
+                                Value="Visible" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Style>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Viewbox>
+                <TextBlock Text="{Binding Message}" />
+            </Viewbox>
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary>

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/MenuViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/MenuViewModel.cs
@@ -17,17 +17,19 @@ public sealed partial class MenuViewModel : ObservableObject, IDisposable
     private readonly IUpbeatService _upbeatService;
     private readonly Action _closeApplicationCallback;
     private readonly SharedTimer _sharedTimer;
+    private readonly OverlayService _overlayService;
     private readonly Stopwatch _stopwatch = new();
 
     public MenuViewModel(
         IUpbeatService upbeatService, // This will be a unique IUpbeatService created and injected by the IUpbeatStack specifically for this ViewModel.
         Action closeApplicationCallback, // This ViewModel requires an Action delegate to be provided, so it can start closing the application.
-        SharedTimer sharedTimer) // This is a shared singleton service.
+        SharedTimer sharedTimer, // This is a shared singleton service.
+        OverlayService overlayService) // This is a shared singleton service.
     {
         _upbeatService = upbeatService ?? throw new ArgumentNullException(nameof(upbeatService));
         _closeApplicationCallback = closeApplicationCallback ?? throw new ArgumentNullException(nameof(closeApplicationCallback));
         _sharedTimer = sharedTimer ?? throw new ArgumentNullException(nameof(sharedTimer));
-
+        _overlayService = overlayService ?? throw new ArgumentNullException(nameof(overlayService));
         _stopwatch.Start();
         _upbeatService.RegisterUpdateCallback(() => OnPropertyChanged(nameof(Visibility))); // Registered "UpdateCallbacks" will be called each time the UI thread renders a new frame.
 
@@ -36,6 +38,16 @@ public sealed partial class MenuViewModel : ObservableObject, IDisposable
 
     public string SecondsElapsed => $"{_sharedTimer.ElapsedSeconds} Seconds";
     public double Visibility => Math.Abs(1000.0 - _stopwatch.ElapsedMilliseconds % 2000) / 1000.0; // Will be calculated on each "OnPropertyChanged(nameof(Visibility))" and used in the View to control visibility of an ellipse. Cycles between full and no visibility every two seconds.
+    public bool ShowOverlay
+    {
+        get => _overlayService.OverlayVisible;
+        set => SetProperty(
+            _overlayService.OverlayVisible,
+            value,
+            _overlayService,
+            (os, v) => os.OverlayVisible = v);
+    }
+
 
     // RelayCommand is an ICommand implementation from the CommunityToolkit.Mvvm NuGet package. As an attribute, it can be used to automatically wrap methods within ICommand properties. It supports both async and non-async methods/lambdas.
     [RelayCommand]

--- a/samples/ServiceProvidedUpbeatUISample/ViewModel/OverlayViewModel.cs
+++ b/samples/ServiceProvidedUpbeatUISample/ViewModel/OverlayViewModel.cs
@@ -1,0 +1,30 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ServiceProvidedUpbeatUISample.ViewModel;
+
+// This extends ObservableObject from the CommunityToolkit.Mvvm NuGet package, which provides pre-written SetProperty and OnPropertyChanged methods.
+public sealed partial class OverlayViewModel : ObservableObject, IDisposable
+{
+    private readonly OverlayService _overlayService;
+    [ObservableProperty]
+    private string _message = "Overlay";
+    [ObservableProperty]
+    private bool _visible;
+
+    public OverlayViewModel(OverlayService overlayService)
+    {
+        _overlayService = overlayService ?? throw new ArgumentNullException(nameof(overlayService));
+        _overlayService.OverlayToggled += HandleOverlayToggled;
+    }
+
+    public void Dispose() =>
+        _overlayService.OverlayToggled -= HandleOverlayToggled;
+
+    private void HandleOverlayToggled(object sender, EventArgs e) =>
+        Visible = _overlayService.OverlayVisible;
+}

--- a/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
+++ b/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
@@ -22,8 +22,8 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>2.2.0</Version>
-        <PackageValidationBaselineVersion>2.1.0</PackageValidationBaselineVersion>
+        <Version>2.3.0-rc1</Version>
+        <PackageValidationBaselineVersion>2.2.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/UpbeatUI.Extensions.Hosting/HostedUpbeatBuilder.cs
+++ b/source/UpbeatUI.Extensions.Hosting/HostedUpbeatBuilder.cs
@@ -126,6 +126,7 @@ namespace UpbeatUI.Extensions.Hosting
                 overlayViewModelCreator == null ? null : new Func<IServiceProvider, object>(_ => overlayViewModelCreator));
 
         public IHostedUpbeatBuilder SetOverlayViewModel<TOverlayViewModel>() =>
-            SetOverlayViewModel(sp => ActivatorUtilities.CreateInstance<TOverlayViewModel>(sp));
+            SetOverlayViewModel(
+                sp => sp.GetService(typeof(TOverlayViewModel)) ?? ActivatorUtilities.CreateInstance<TOverlayViewModel>(sp));
     }
 }

--- a/source/UpbeatUI.Extensions.Hosting/HostedUpbeatService.cs
+++ b/source/UpbeatUI.Extensions.Hosting/HostedUpbeatService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using UpbeatUI.Extensions.DependencyInjection;
 using UpbeatUI.View;
@@ -62,8 +63,10 @@ namespace UpbeatUI.Extensions.Hosting
                     {
                         registerer.Invoke(upbeatStack);
                     }
-                    var overlayViewModel = _upbeatHostBuilder.OverlayViewModelCreator?.Invoke(_serviceProvider);
-                    _mainWindow = (_upbeatHostBuilder.WindowCreator ?? new Func<IServiceProvider, IUpbeatStack, object, Window>((sp, us, ovm) => new UpbeatMainWindow())).Invoke(_serviceProvider, upbeatStack, overlayViewModel);
+                    using var overlayScope = _serviceProvider.CreateScope();
+                    var overlayViewModel = _upbeatHostBuilder.OverlayViewModelCreator?.Invoke(overlayScope.ServiceProvider);
+                    _mainWindow = (_upbeatHostBuilder.WindowCreator ?? new Func<IServiceProvider, IUpbeatStack, object, Window>((sp, us, ovm) => new UpbeatMainWindow()))
+                        .Invoke(_serviceProvider, upbeatStack, overlayViewModel);
                     _mainWindow.Closing += HandleMainWindowClosing;
                     upbeatStack.ViewModelsEmptied += HandleUpbeatStackViewModelsEmptied;
                     Application.Current.DispatcherUnhandledException += HandleApplicationException;

--- a/source/UpbeatUI.Extensions.Hosting/HostedUpbeatService.cs
+++ b/source/UpbeatUI.Extensions.Hosting/HostedUpbeatService.cs
@@ -68,9 +68,9 @@ namespace UpbeatUI.Extensions.Hosting
                     try
                     {
                         _mainWindow.DataContext = upbeatStack;
-                        if (_mainWindow is UpbeatMainWindow upbeatMainWindow)
+                        if (_mainWindow is IOverlayWindow overlayWindow)
                         {
-                            upbeatMainWindow.OverlayDataContext = _upbeatHostBuilder.OverlayViewModelCreator?.Invoke(_serviceProvider);
+                            overlayWindow.OverlayDataContext = _upbeatHostBuilder.OverlayViewModelCreator?.Invoke(_serviceProvider);
                         }
                         upbeatStack.OpenViewModel(_upbeatHostBuilder.BaseViewModelParametersCreator?.Invoke() ?? throw new InvalidOperationException($"No {nameof(_upbeatHostBuilder.BaseViewModelParametersCreator)} provided."));
                         _mainWindow.Show();
@@ -97,9 +97,9 @@ namespace UpbeatUI.Extensions.Hosting
                     }
                     finally
                     {
-                        if (_mainWindow is UpbeatMainWindow upbeatMainWindow)
+                        if (_mainWindow is IOverlayWindow overlayWindow)
                         {
-                            (upbeatMainWindow.OverlayDataContext as IDisposable)?.Dispose();
+                            (overlayWindow.OverlayDataContext as IDisposable)?.Dispose();
                         }
                         Application.Current.DispatcherUnhandledException -= HandleApplicationException;
                         upbeatStack.ViewModelsEmptied -= HandleUpbeatStackViewModelsEmptied;

--- a/source/UpbeatUI.Extensions.Hosting/IHostedUpbeatBuilder.cs
+++ b/source/UpbeatUI.Extensions.Hosting/IHostedUpbeatBuilder.cs
@@ -4,6 +4,7 @@
  */
 using System;
 using System.Windows;
+using UpbeatUI.View;
 using UpbeatUI.ViewModel;
 
 namespace UpbeatUI.Extensions.Hosting
@@ -109,5 +110,25 @@ namespace UpbeatUI.Extensions.Hosting
         IHostedUpbeatBuilder SetViewModelLocators(
             Func<Type, Type> parameterToViewModelLocator,
             bool allowUnresolvedDependencies = false);
+
+        /// <summary>
+        /// Sets an optional delegate to provide a ViewModel that the <see cref="UpbeatMainWindow"/> will use to display an overlay View. Overlay Views are rendered on top of all other application content, but are not hit test visible.
+        /// </summary>
+        /// <param name="overlayViewModelCreator">The delegate that will create the overlay ViewModel</param>
+        /// <returns>The <see cref="IHostedUpbeatBuilder"/> for chaining.</returns>
+        IHostedUpbeatBuilder SetOverlayViewModel(Func<IServiceProvider, object> overlayViewModelCreator);
+
+        /// <summary>
+        /// Sets an optional delegate to provide a ViewModel that the <see cref="UpbeatMainWindow"/> will use to display an overlay View. Overlay Views are rendered on top of all other application content, but are not hit test visible.
+        /// </summary>
+        /// <returns>The <see cref="IHostedUpbeatBuilder"/> for chaining.</returns>
+        IHostedUpbeatBuilder SetOverlayViewModel(Func<object> overlayViewModelCreator);
+
+        /// <summary>
+        /// Sets an optional delegate to provide a ViewModel that the <see cref="UpbeatMainWindow"/> will use to display an overlay View. Overlay Views are rendered on top of all other application content, but are not hit test visible.
+        /// </summary>
+        /// <typeparam name="TOverlayViewModel">The type of the overlay ViewModel. This type will be instantiated automatically using the application's <see cref="IServiceProvider"/></typeparam>
+        /// <returns>The <see cref="IHostedUpbeatBuilder"/> for chaining.</returns>
+        IHostedUpbeatBuilder SetOverlayViewModel<TOverlayViewModel>();
     }
 }

--- a/source/UpbeatUI.Extensions.Hosting/IHostedUpbeatBuilder.cs
+++ b/source/UpbeatUI.Extensions.Hosting/IHostedUpbeatBuilder.cs
@@ -15,11 +15,33 @@ namespace UpbeatUI.Extensions.Hosting
     public interface IHostedUpbeatBuilder
     {
         /// <summary>
-        /// Sets a delegate for building the main <see cref="Window"/> that will house the UpbeatUI aplication. The <see cref="Window"/>'s DataContext will be set by the service.
+        /// Sets a delegate for building the main <see cref="Window"/> that will house the UpbeatUI aplication. The <see cref="Window"/>'s <see cref="FrameworkElement.DataContext"/> (and optionally <see cref="UpbeatMainWindow.OverlayDataContext"/>) must be set in the <paramref name="windowCreator"/> delegate.
+        /// </summary>
+        /// <param name="windowCreator">The delegate for creating the main <see cref="Window"/> using the application's <see cref="IServiceProvider"/>. The delegate's <see cref="IUpbeatStack"/> parameter must be assigned to the <see cref="Window"/>'s or a child element's <see cref="FrameworkElement.DataContext"/> property. The delegate's  <see cref="object"/> parameter represents a possible overlay ViewModel and should be assigned appropriately if the <see cref="Window"/> will display an overlay View.</param>
+        /// <returns>The <see cref="IHostedUpbeatBuilder"/> for chaining.</returns>
+        IHostedUpbeatBuilder ConfigureWindow(Func<IServiceProvider, IUpbeatStack, object, Window> windowCreator);
+
+        /// <summary>
+        /// Sets a delegate for building the main <see cref="Window"/> that will house the UpbeatUI aplication. The <see cref="Window"/>'s <see cref="FrameworkElement.DataContext"/> will be set by the service.
+        /// </summary>
+        /// <param name="windowCreator">The delegate for creating the main <see cref="Window"/> using the application's <see cref="IServiceProvider"/>.</param>
+        /// <returns>The <see cref="IHostedUpbeatBuilder"/> for chaining.</returns>
+        IHostedUpbeatBuilder ConfigureWindow(Func<IServiceProvider, Window> windowCreator);
+
+        /// <summary>
+        /// Sets a delegate for building the main <see cref="Window"/> that will house the UpbeatUI aplication. The <see cref="Window"/>'s <see cref="FrameworkElement.DataContext"/> will be set by the service.
         /// </summary>
         /// <param name="windowCreator">The delegate for creating the main <see cref="Window"/>.</param>
         /// <returns>The <see cref="IHostedUpbeatBuilder"/> for chaining.</returns>
         IHostedUpbeatBuilder ConfigureWindow(Func<Window> windowCreator);
+
+        /// <summary>
+        /// Sets the type for the main <see cref="Window"/> that will house the UpbeatUI aplication. The <see cref="Window"/>'s <see cref="FrameworkElement.DataContext"/> will be set by the service.
+        /// </summary>
+        /// <typeparam name="TWindow">The type of the Window; must be a subclass of <see cref="Window"/> and must implement a parameter-less constructor.</typeparam>
+        /// <returns>The <see cref="IHostedUpbeatBuilder"/> for chaining.</returns>
+        IHostedUpbeatBuilder ConfigureWindow<TWindow>()
+            where TWindow : Window, new();
 
         /// <summary>
         /// Sets a delegate for building the bottom/base ViewModel.

--- a/source/UpbeatUI.Extensions.Hosting/IHostedUpbeatBuilder.cs
+++ b/source/UpbeatUI.Extensions.Hosting/IHostedUpbeatBuilder.cs
@@ -4,6 +4,7 @@
  */
 using System;
 using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
 using UpbeatUI.View;
 using UpbeatUI.ViewModel;
 
@@ -136,20 +137,21 @@ namespace UpbeatUI.Extensions.Hosting
         /// <summary>
         /// Sets an optional delegate to provide a ViewModel that the <see cref="UpbeatMainWindow"/> will use to display an overlay View. Overlay Views are rendered on top of all other application content, but are not hit test visible.
         /// </summary>
-        /// <param name="overlayViewModelCreator">The delegate that will create the overlay ViewModel</param>
+        /// <param name="overlayViewModelCreator">The delegate that will create the overlay ViewModel using the application's <see cref="IServiceProvider"/>.</param>
         /// <returns>The <see cref="IHostedUpbeatBuilder"/> for chaining.</returns>
         IHostedUpbeatBuilder SetOverlayViewModel(Func<IServiceProvider, object> overlayViewModelCreator);
 
         /// <summary>
         /// Sets an optional delegate to provide a ViewModel that the <see cref="UpbeatMainWindow"/> will use to display an overlay View. Overlay Views are rendered on top of all other application content, but are not hit test visible.
         /// </summary>
+        /// <param name="overlayViewModelCreator">The delegate that will create the overlay ViewModel.</param>
         /// <returns>The <see cref="IHostedUpbeatBuilder"/> for chaining.</returns>
         IHostedUpbeatBuilder SetOverlayViewModel(Func<object> overlayViewModelCreator);
 
         /// <summary>
         /// Sets an optional delegate to provide a ViewModel that the <see cref="UpbeatMainWindow"/> will use to display an overlay View. Overlay Views are rendered on top of all other application content, but are not hit test visible.
         /// </summary>
-        /// <typeparam name="TOverlayViewModel">The type of the overlay ViewModel. This type will be instantiated automatically using the application's <see cref="IServiceProvider"/></typeparam>
+        /// <typeparam name="TOverlayViewModel">The type of the overlay ViewModel. If the type is a service that was added to the application's <see cref="IServiceCollection"/>, then that service (or an instance of it if added as transient or scoped) will be retrieved from the application's <see cref="IServiceProvider"/>. Otherwise, an instance of the type will be constructed using the <see cref="IServiceProvider"/>.</typeparam>
         /// <returns>The <see cref="IHostedUpbeatBuilder"/> for chaining.</returns>
         IHostedUpbeatBuilder SetOverlayViewModel<TOverlayViewModel>();
     }

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -22,7 +22,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>5.0.0-rc3</Version>
+        <Version>5.0.0-rc4</Version>
         <!-- <PackageValidationBaselineVersion>4.2.0</PackageValidationBaselineVersion> -->
     </PropertyGroup>
 

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -22,7 +22,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>5.0.0-rc4</Version>
+        <Version>5.0.0-rc5</Version>
         <!-- <PackageValidationBaselineVersion>4.2.0</PackageValidationBaselineVersion> -->
     </PropertyGroup>
 

--- a/source/UpbeatUI/UpbeatUI.csproj
+++ b/source/UpbeatUI/UpbeatUI.csproj
@@ -23,8 +23,8 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>5.2.0</Version>
-        <PackageValidationBaselineVersion>5.1.0</PackageValidationBaselineVersion>
+        <Version>5.3.0-rc1</Version>
+        <PackageValidationBaselineVersion>5.2.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/UpbeatUI/View/IOverlayWindow.cs
+++ b/source/UpbeatUI/View/IOverlayWindow.cs
@@ -1,0 +1,29 @@
+/* This file is part of the UpbeatUI project, which is released under MIT License.
+ * See LICENSE.md or visit:
+ * https://github.com/pulselyre/upbeatui/blob/main/LICENSE.md
+ */
+using System.Windows;
+
+namespace UpbeatUI.View
+{
+    /// <summary>
+    /// Defines a <see cref="DependencyProperty"/> and property for a <see cref="Window"/> with an <see cref="OverlayDataContext"/> for an overlay View.
+    /// </summary>
+    public interface IOverlayWindow
+    {
+        /// <summary>
+        /// Identifies the <see cref="OverlayDataContext"/> <see cref="DependencyProperty"/>.
+        /// </summary>
+        public static readonly DependencyProperty OverlayDataContextProperty =
+            DependencyProperty.Register(
+                "OverlayDataContext",
+                typeof(object),
+                typeof(UIElement),
+                new FrameworkPropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets a the data context for the <see cref="Window"/>'s optional overlay element.
+        /// </summary>
+        object OverlayDataContext { get; set; }
+    }
+}

--- a/source/UpbeatUI/View/UpbeatMainWindow.xaml
+++ b/source/UpbeatUI/View/UpbeatMainWindow.xaml
@@ -20,7 +20,9 @@
                     Property="Margin"
                     Value="0" />
                 <Style.Triggers>
-                    <DataTrigger Binding="{Binding Fullscreen, ElementName=_upbeatMainWindow}" Value="True">
+                    <DataTrigger
+                        Binding="{Binding Fullscreen, ElementName=_upbeatMainWindow}"
+                        Value="True">
                         <Setter
                             Property="Margin"
                             Value="{Binding FullscreenContentMargin, ElementName=_upbeatMainWindow}" />
@@ -55,5 +57,8 @@
                 </Style>
             </ItemsControl.ItemContainerStyle>
         </ItemsControl>
+        <ContentPresenter
+            Content="{Binding OverlayDataContext, ElementName=_upbeatMainWindow}"
+            IsHitTestVisible="False" />
     </Grid>
 </Window>

--- a/source/UpbeatUI/View/UpbeatMainWindow.xaml.cs
+++ b/source/UpbeatUI/View/UpbeatMainWindow.xaml.cs
@@ -16,7 +16,7 @@ namespace UpbeatUI.View
         /// <summary>
         /// Identifies the <see cref="Fullscreen"/> <see cref="DependencyProperty"/>.
         /// </summary>
-        public readonly static DependencyProperty FullscreenProperty =
+        public static readonly DependencyProperty FullscreenProperty =
             DependencyProperty.Register(
                 "Fullscreen",
                 typeof(bool),
@@ -26,7 +26,7 @@ namespace UpbeatUI.View
         /// <summary>
         /// Identifies the <see cref="FullscreenContentMargin"/> <see cref="DependencyProperty"/>.
         /// </summary>
-        public readonly static DependencyProperty FullscreenContentMarginProperty =
+        public static readonly DependencyProperty FullscreenContentMarginProperty =
             DependencyProperty.Register(
                 "FullscreenContentMargin",
                 typeof(Thickness),
@@ -36,16 +36,26 @@ namespace UpbeatUI.View
         /// <summary>
         /// Identifies the <see cref="ModalBackground"/> <see cref="DependencyProperty"/>.
         /// </summary>
-        public readonly static DependencyProperty ModalBackgroundProperty =
+        public static readonly DependencyProperty ModalBackgroundProperty =
             ModalPanel.ModalBackgroundProperty.AddOwner(typeof(UpbeatMainWindow));
 
         /// <summary>
         /// Identifies the <see cref="ModalBlurEffect"/> <see cref="DependencyProperty"/>.
         /// </summary>
-        public readonly static DependencyProperty ModalBlurEffectProprety =
+        public static readonly DependencyProperty ModalBlurEffectProprety =
             DependencyProperty.Register(
                 "ModalBlurEffect",
                 typeof(BlurEffect),
+                typeof(UpbeatMainWindow),
+                new FrameworkPropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="OverlayDataContext"/> <see cref="DependencyProperty"/>.
+        /// </summary>
+        public static readonly DependencyProperty OverlayDataContextProperty =
+            DependencyProperty.Register(
+                "OverlayDataContext",
+                typeof(object),
                 typeof(UpbeatMainWindow),
                 new FrameworkPropertyMetadata(null));
 
@@ -91,6 +101,15 @@ namespace UpbeatUI.View
         {
             get => (BlurEffect)GetValue(ModalBlurEffectProprety);
             set => SetValue(ModalBlurEffectProprety, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a the data context for the <see cref="UpbeatMainWindow"/>'s optional overlay element.
+        /// </summary>
+        public object OverlayDataContext
+        {
+            get => GetValue(OverlayDataContextProperty);
+            set => SetValue(OverlayDataContextProperty, value);
         }
 
         private static void HandleFullscreenPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/source/UpbeatUI/View/UpbeatMainWindow.xaml.cs
+++ b/source/UpbeatUI/View/UpbeatMainWindow.xaml.cs
@@ -11,7 +11,7 @@ namespace UpbeatUI.View
     /// <summary>
     /// Defines a window with a pre-embedded <see cref="ModalPanel"/> to stack Views. The <see cref="FrameworkElement.DataContext"/> property should be set to an <see cref="ViewModel.IUpbeatStack"/> instance.
     /// </summary>
-    public partial class UpbeatMainWindow : Window
+    public partial class UpbeatMainWindow : Window, IOverlayWindow
     {
         /// <summary>
         /// Identifies the <see cref="Fullscreen"/> <see cref="DependencyProperty"/>.
@@ -53,11 +53,7 @@ namespace UpbeatUI.View
         /// Identifies the <see cref="OverlayDataContext"/> <see cref="DependencyProperty"/>.
         /// </summary>
         public static readonly DependencyProperty OverlayDataContextProperty =
-            DependencyProperty.Register(
-                "OverlayDataContext",
-                typeof(object),
-                typeof(UpbeatMainWindow),
-                new FrameworkPropertyMetadata(null));
+            IOverlayWindow.OverlayDataContextProperty.AddOwner(typeof(UpbeatMainWindow));
 
         /// <summary>
         /// Initializes a new <see cref="UpbeatMainWindow"/>.


### PR DESCRIPTION
1. Adds an optional `OverlayDataContext` property to the `UpbeatMainWindow` that will show a `IsHitTestVisible="False"` element on top of all other content. This is useful to maybe show a "beta version" banner or possibly a spinner when an app is working. The overlay will be displayed from a template mapped to the view model type like any other layer in the application.
2. Adds new methods to the `IUpbeatBuilder` interface and (and implementation class) to set the `OverlayDataContext` (using the application's `IServiceProvider` if necessary).
3. Adds more method options to the `IUpbeatBuilder` for main window creation, with the option to use the application's `IServiceProvider` if necessary, and to manually set the `IUpbeatStack` and overview viewmodel to the appropriate `DataContext` properties.