### PR TITLE
Improves error reporting when ServiceProvidedUpbeatStack is unable to instantiate a ViewModel

### DIFF
--- a/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
+++ b/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
@@ -23,7 +23,7 @@
     <ItemGroup>
         <PackageReference
             Include="UpbeatUI.Extensions.Hosting"
-            Version="5.0.0-rc5" />
+            Version="5.1.0-rc1" />
         <!-- Switch from the PackageReference to the ProjectReference to test local UpbeatUI changes in the samples. -->
         <!-- <ProjectReference Include="..\..\source\UpbeatUI.Extensions.Hosting\UpbeatUI.Extensions.Hosting.csproj" /> -->
     </ItemGroup>

--- a/samples/ServiceProvidedUpbeatUISample/ServiceProvidedUpbeatUISample.csproj
+++ b/samples/ServiceProvidedUpbeatUISample/ServiceProvidedUpbeatUISample.csproj
@@ -23,7 +23,7 @@
     <ItemGroup>
         <PackageReference
             Include="UpbeatUI.Extensions.DependencyInjection"
-            Version="2.3.0-rc1" />
+            Version="2.4.0-rc1" />
         <!-- Switch from the PackageReference to the ProjectReference to test local UpbeatUI changes in the samples. -->
         <!-- <ProjectReference Include="..\..\source\UpbeatUI.Extensions.DependencyInjection\UpbeatUI.Extensions.DependencyInjection.csproj" /> -->
     </ItemGroup>

--- a/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
+++ b/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
@@ -22,8 +22,8 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>2.3.0</Version>
-        <PackageValidationBaselineVersion>2.2.0</PackageValidationBaselineVersion>
+        <Version>2.4.0-rc1</Version>
+        <PackageValidationBaselineVersion>2.3.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -22,8 +22,8 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>5.0.0</Version>
-        <!-- <PackageValidationBaselineVersion>4.2.0</PackageValidationBaselineVersion> -->
+        <Version>5.1.0-rc1</Version>
+        <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
1. Adds various `InvalidOperationException` throws to the `ResolveDependency` method if needed `Type` is an interface, is an abstract class, or does not have exactly one constructor.
2. Aggregates all failed dependency resolution approaches into an `AggregateException`.