### PR TITLE
Provides additional exception wrapping when unable to create ViewModel or dependencies

### DIFF
--- a/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
+++ b/samples/HostedUpbeatUISample/HostedUpbeatUISample.csproj
@@ -23,7 +23,7 @@
     <ItemGroup>
         <PackageReference
             Include="UpbeatUI.Extensions.Hosting"
-            Version="5.1.0-rc1" />
+            Version="5.1.0-rc2" />
         <!-- Switch from the PackageReference to the ProjectReference to test local UpbeatUI changes in the samples. -->
         <!-- <ProjectReference Include="..\..\source\UpbeatUI.Extensions.Hosting\UpbeatUI.Extensions.Hosting.csproj" /> -->
     </ItemGroup>

--- a/samples/ServiceProvidedUpbeatUISample/ServiceProvidedUpbeatUISample.csproj
+++ b/samples/ServiceProvidedUpbeatUISample/ServiceProvidedUpbeatUISample.csproj
@@ -23,7 +23,7 @@
     <ItemGroup>
         <PackageReference
             Include="UpbeatUI.Extensions.DependencyInjection"
-            Version="2.4.0-rc1" />
+            Version="2.4.0-rc2" />
         <!-- Switch from the PackageReference to the ProjectReference to test local UpbeatUI changes in the samples. -->
         <!-- <ProjectReference Include="..\..\source\UpbeatUI.Extensions.DependencyInjection\UpbeatUI.Extensions.DependencyInjection.csproj" /> -->
     </ItemGroup>

--- a/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
+++ b/source/UpbeatUI.Extensions.DependencyInjection/UpbeatUI.Extensions.DependencyInjection.csproj
@@ -22,7 +22,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>2.4.0-rc1</Version>
+        <Version>2.4.0-rc2</Version>
         <PackageValidationBaselineVersion>2.3.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 

--- a/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
+++ b/source/UpbeatUI.Extensions.Hosting/UpbeatUI.Extensions.Hosting.csproj
@@ -22,7 +22,7 @@
         <Copyright>© Michael P. Duda 2020-2024</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- Update the following properties when publishing a new Nuget version -->
-        <Version>5.1.0-rc1</Version>
+        <Version>5.1.0-rc2</Version>
         <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
1. Wraps `Exception`s thrown when unable to resolve or create a dependency for a ViewModel (or a nested dependency) to make it more clear what operation failed.